### PR TITLE
th/wait-nm: implement waiting for activation/deactivation

### DIFF
--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -655,7 +655,7 @@ class ArgValidator_DictConnection(ArgValidatorDict):
             nested = [
                 ArgValidatorStr ('name'),
                 ArgValidatorStr ('state', enum_values = ArgValidator_DictConnection.VALID_STATES),
-                ArgValidatorNum ('wait', val_min = 0, val_max = 3600),
+                ArgValidatorNum ('wait', val_min = 0, val_max = 3600, numeric_type = float),
                 ArgValidatorStr ('type', enum_values = ArgValidator_DictConnection.VALID_TYPES),
                 ArgValidatorBool('autoconnect', default_value = True),
                 ArgValidatorStr ('slave_type', enum_values = ArgValidator_DictConnection.VALID_SLAVE_TYPES),

--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -453,18 +453,25 @@ class ArgValidatorStr(ArgValidator):
             raise ValidationError(name, 'cannot be empty')
         return v
 
-class ArgValidatorInt(ArgValidator):
-    def __init__(self, name, required = False, val_min = None, val_max = None, default_value = 0):
-        ArgValidator.__init__(self, name, required, default_value)
+class ArgValidatorNum(ArgValidator):
+    def __init__(self, name, required = False, val_min = None, val_max = None,
+                 default_value = ArgValidator.MISSING,
+                 numeric_type = int):
+        ArgValidator.__init__(self, name, required, \
+                              numeric_type(0) if default_value is ArgValidator.MISSING else default_value)
         self.val_min = val_min
         self.val_max = val_max
+        self.numeric_type = numeric_type
     def _validate(self, value, name):
         v = None
         try:
-            if isinstance(value, int):
+            if isinstance(value, self.numeric_type):
                 v = value
-            if isinstance(value, Util.STRING_TYPE):
-                v = int(value)
+            else:
+                v2 = self.numeric_type(value)
+                if     isinstance(value, Util.STRING_TYPE) \
+                    or v2 == value:
+                    v = v2
         except:
             pass
         if v is None:
@@ -590,10 +597,10 @@ class ArgValidator_DictIP(ArgValidatorDict):
                 ArgValidatorBool('dhcp4', default_value = None),
                 ArgValidatorBool('dhcp4_send_hostname', default_value = None),
                 ArgValidatorIP  ('gateway4', family = socket.AF_INET),
-                ArgValidatorInt ('route_metric4', val_min = -1, val_max = 0xFFFFFFFF, default_value = None),
+                ArgValidatorNum ('route_metric4', val_min = -1, val_max = 0xFFFFFFFF, default_value = None),
                 ArgValidatorBool('auto6', default_value = None),
                 ArgValidatorIP  ('gateway6', family = socket.AF_INET6),
-                ArgValidatorInt ('route_metric6', val_min = -1, val_max = 0xFFFFFFFF, default_value = None),
+                ArgValidatorNum ('route_metric6', val_min = -1, val_max = 0xFFFFFFFF, default_value = None),
                 ArgValidatorList('address',
                     nested = ArgValidatorIPAddr('address[?]'),
                     default_value = list,
@@ -648,7 +655,7 @@ class ArgValidator_DictConnection(ArgValidatorDict):
             nested = [
                 ArgValidatorStr ('name'),
                 ArgValidatorStr ('state', enum_values = ArgValidator_DictConnection.VALID_STATES),
-                ArgValidatorInt ('wait', val_min = 0, val_max = 3600),
+                ArgValidatorNum ('wait', val_min = 0, val_max = 3600),
                 ArgValidatorStr ('type', enum_values = ArgValidator_DictConnection.VALID_TYPES),
                 ArgValidatorBool('autoconnect', default_value = True),
                 ArgValidatorStr ('slave_type', enum_values = ArgValidator_DictConnection.VALID_SLAVE_TYPES),
@@ -657,7 +664,7 @@ class ArgValidator_DictConnection(ArgValidatorDict):
                 ArgValidatorMac ('mac'),
                 ArgValidatorBool('check_iface_exists', default_value = True),
                 ArgValidatorStr ('parent'),
-                ArgValidatorInt ('vlan_id', val_min = 0, val_max = 4095, default_value = None),
+                ArgValidatorNum ('vlan_id', val_min = 0, val_max = 4095, default_value = None),
                 ArgValidatorBool('ignore_errors', default_value = None),
                 ArgValidator_DictIP(),
             ],

--- a/library/test_network_connections.py
+++ b/library/test_network_connections.py
@@ -134,7 +134,7 @@ class TestValidator(unittest.TestCase):
                 {
                     'name': '5',
                     'state': 'up',
-                    'wait': 90,
+                    'wait': None,
                     'ignore_errors': None,
                 }
             ],
@@ -173,7 +173,7 @@ class TestValidator(unittest.TestCase):
                     'interface_name': None,
                     'check_iface_exists': True,
                     'slave_type': None,
-                    'wait': 90,
+                    'wait': None,
                 },
             ],
             n.AnsibleUtil.ARGS_CONNECTIONS.validate([
@@ -275,7 +275,7 @@ class TestValidator(unittest.TestCase):
                     'interface_name': None,
                     'check_iface_exists': True,
                     'slave_type': None,
-                    'wait': 90,
+                    'wait': None,
                 },
             ],
             n.AnsibleUtil.ARGS_CONNECTIONS.validate([
@@ -314,7 +314,7 @@ class TestValidator(unittest.TestCase):
                     'interface_name': None,
                     'check_iface_exists': True,
                     'slave_type': None,
-                    'wait': 90,
+                    'wait': None,
                 },
             ],
             n.AnsibleUtil.ARGS_CONNECTIONS.validate([
@@ -355,7 +355,7 @@ class TestValidator(unittest.TestCase):
                     'interface_name': None,
                     'check_iface_exists': True,
                     'slave_type': None,
-                    'wait': 90,
+                    'wait': None,
                 },
             ],
             n.AnsibleUtil.ARGS_CONNECTIONS.validate([

--- a/library/test_network_connections.py
+++ b/library/test_network_connections.py
@@ -27,13 +27,23 @@ class TestValidator(unittest.TestCase):
 
     def test_validate_int(self):
 
-        v = n.ArgValidatorInt('state', default_value = None)
+        v = n.ArgValidatorNum('state', default_value = None, numeric_type = float)
         self.assertEqual(1, v.validate(1))
-        self.assertEqual(1, v.validate("1"))
+        self.assertEqual(1.5, v.validate(1.5))
+        self.assertEqual(1.5, v.validate("1.5"))
         self.assertValidationError(v, None)
         self.assertValidationError(v, "1a")
 
-        v = n.ArgValidatorInt('state', required = True)
+        v = n.ArgValidatorNum('state', default_value = None)
+        self.assertEqual(1, v.validate(1))
+        self.assertEqual(1, v.validate(1.0))
+        self.assertEqual(1, v.validate("1"))
+        self.assertValidationError(v, None)
+        self.assertValidationError(v, None)
+        self.assertValidationError(v, 1.5)
+        self.assertValidationError(v, "1.5")
+
+        v = n.ArgValidatorNum('state', required = True)
         self.assertValidationError(v, None)
 
     def test_validate_bool(self):
@@ -56,7 +66,7 @@ class TestValidator(unittest.TestCase):
         v = n.ArgValidatorDict(
             'dict',
             nested = [
-                n.ArgValidatorInt('i', required = True),
+                n.ArgValidatorNum('i', required = True),
                 n.ArgValidatorStr('s', required = False, default_value = 's_default'),
                 n.ArgValidatorStr('l', required = False, default_value = n.ArgValidator.MISSING),
             ])
@@ -87,7 +97,7 @@ class TestValidator(unittest.TestCase):
 
         v = n.ArgValidatorList(
             'list',
-            nested = n.ArgValidatorInt('i')
+            nested = n.ArgValidatorNum('i')
         )
         self.assertEqual(
             [ 1, 5 ],


### PR DESCRIPTION
When activating/deactivation a connection with NetworkManager, implement the 'wait' option to wait for the operation to complete. This is what `nmcli connection up|down` does, depending on the `--wait` option.