### PR TITLE
role: improve making "network_provider" configurable via host vars

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,35 @@
-network_provider: "{{ network_provider_default }}"
-network_connections: []
+network_provider:     "{{ network_provider_default }}"
+network_connections:  []
+
+network_service_name_default_nm: NetworkManager
+network_packages_default_nm: [ NetworkManager ]
+
+network_service_name_default_initscripts: network
+network_packages_default_initscripts: []
+
+
+# The user can set host variables "network_provider",
+# "network_service_name" and "network_packages".
+#
+# Usually, he only wants to select the "network_provider"
+# (or not set it at all and let it be autodetected via the
+# internal variable "{{ network_provider_default }}". Hence,
+# depending on the "network_provider", a different set of
+# service-name and packages is used.
+#
+# That is done via the internal "_network_provider_setup" dictionary.
+# If the user doesn't explicitly set "network_service_name" or
+# "network_packages" (which he usually wouldn't), then the defaults
+# from "network_service_name_default_*" and "network_packages_default_*"
+# apply. These values are hard-coded here too, but they could also
+# be overwritten as hot variables or in vars/*.yml.
+_network_provider_setup:
+    nm:
+        service_name: "{{ network_service_name_default_nm }}"
+        packages:     "{{ network_packages_default_nm }}"
+    initscripts:
+        service_name: "{{ network_service_name_default_initscripts }}"
+        packages:     "{{ network_packages_default_initscripts }}"
+
+network_packages:     "{{ _network_provider_setup[network_provider]['packages'] }}"
+network_service_name: "{{ _network_provider_setup[network_provider]['service_name'] }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,9 +6,26 @@
       - "{{ ansible_os_family }}.yml"
       - "default.yml"
 
+
+- name: Print setting network_provider
+  debug:
+      var: network_provider
+      verbosity: 2
+
+- name: Print setting network_packages
+  debug:
+      var: network_packages
+      verbosity: 2
+
+- name: Print setting network_service_name
+  debug:
+      var: network_service_name
+      verbosity: 2
+
+
 - name: Install packages
   package:
-      name: "{{ network_packages | default([]) }}"
+      name: "{{ network_packages }}"
       state: present
 
 - name: Enable network service

--- a/vars/default-initscripts.yml
+++ b/vars/default-initscripts.yml
@@ -1,2 +1,1 @@
-network_service_name: network
 network_provider_default: initscripts

--- a/vars/default-nm.yml
+++ b/vars/default-nm.yml
@@ -1,4 +1,1 @@
-network_service_name: NetworkManager
-network_packages:
-  - NetworkManager
 network_provider_default: nm


### PR DESCRIPTION
The role supports two providers: "nm" and "initscripts".

The provider is autodetected by loading one of the vars/*.yml files
(where the default is loaded as internal "network_provider_default" variable).
The user can still overwrite the provider, by explicitly setting the
"network_provider" variable.

Depending on the provider there is the list of packages that shall be
installed and the service to start. Selecting this was broken before.

This is now fixed and works like following:

The variables "network_service_name" and "network_packages" can be
specified by the user as host variables. But usually one wouldn't
want to do that. In that case, we look into the internal
"_network_provider_setup" dictionary, which uses the variables
"network_service_name_nm", "network_service_name_initscripts",
"network_packages_nm", "network_packages_initscripts".

These variables are initialized in "defaults/main.yml" as well,
but they could be overwritten via "vars/*.yml" files.

https://bugzilla.redhat.com/show_bug.cgi?id=1485074