### PR TITLE
Fix exception when dns is present

### DIFF
--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -634,7 +634,7 @@ class ArgValidator_DictIP(ArgValidatorDict):
                     default_value = list,
                 ),
                 ArgValidatorList('dns',
-                    nested = ArgValidatorIP('dns[?]'),
+                    nested = ArgValidatorIP('dns[?]', plain_address=False),
                     default_value = list,
                 ),
                 ArgValidatorList('dns_search',


### PR DESCRIPTION
ifcfg_create expects list of dns addresses to be non plain values, while
dns validator returns only a string.