### PR TITLE
support for configuring static routes (th/static routes)

### DIFF
--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -517,46 +517,6 @@ class ArgValidatorBool(ArgValidator):
             pass
         raise ValidationError(name, 'must be an boolean but is "%s"' % (value))
 
-class ArgValidatorIP(ArgValidatorStr):
-    def __init__(self, name, family = None, required = False, default_value = None, plain_address = True):
-        ArgValidatorStr.__init__(self, name, required, default_value, None)
-        self.family = family
-        self.plain_address = plain_address
-    def _validate(self, value, name):
-        v = ArgValidatorStr._validate(self, value, name)
-        try:
-            addr, family = Util.parse_ip(v, self.family)
-        except:
-            raise ValidationError(name, 'value "%s" is not a valid IP%s address' % (value, Util.addr_family_to_v(self.family)))
-        if self.plain_address:
-            return addr
-        return { 'is_v4': family == socket.AF_INET, 'family': family, 'address': addr }
-
-class ArgValidatorMac(ArgValidatorStr):
-    def __init__(self, name, force_len = None, required = False, default_value = None):
-        ArgValidatorStr.__init__(self, name, required, default_value, None)
-        self.force_len = force_len
-    def _validate(self, value, name):
-        v = ArgValidatorStr._validate(self, value, name)
-        try:
-            addr = Util.mac_aton(v, self.force_len)
-        except MyError as e:
-            raise ValidationError(name, 'value "%s" is not a valid MAC address' % (value))
-        if not addr:
-            raise ValidationError(name, 'value "%s" is not a valid MAC address' % (value))
-        return Util.mac_ntoa(addr)
-
-class ArgValidatorIPAddr(ArgValidatorStr):
-    def __init__(self, name, family = None, required = False, default_value = None):
-        ArgValidatorStr.__init__(self, name, required, default_value, None)
-        self.family = family
-    def _validate(self, value, name):
-        v = ArgValidatorStr._validate(self, value, name)
-        try:
-            return Util.parse_address(v, self.family)
-        except:
-            raise ValidationError(name, 'value "%s" is not a valid IP%s address with prefix length' % (value, Util.addr_family_to_v(self.family)))
-
 class ArgValidatorDict(ArgValidator):
     def __init__(self, name = None, required = False, nested = None, default_value = None, all_missing_during_validate = False):
         ArgValidator.__init__(self, name, required, default_value)
@@ -616,6 +576,46 @@ class ArgValidatorList(ArgValidator):
                 raise ValidationError(e.name, e.error_message)
             result.append(vv)
         return result
+
+class ArgValidatorIP(ArgValidatorStr):
+    def __init__(self, name, family = None, required = False, default_value = None, plain_address = True):
+        ArgValidatorStr.__init__(self, name, required, default_value, None)
+        self.family = family
+        self.plain_address = plain_address
+    def _validate(self, value, name):
+        v = ArgValidatorStr._validate(self, value, name)
+        try:
+            addr, family = Util.parse_ip(v, self.family)
+        except:
+            raise ValidationError(name, 'value "%s" is not a valid IP%s address' % (value, Util.addr_family_to_v(self.family)))
+        if self.plain_address:
+            return addr
+        return { 'is_v4': family == socket.AF_INET, 'family': family, 'address': addr }
+
+class ArgValidatorMac(ArgValidatorStr):
+    def __init__(self, name, force_len = None, required = False, default_value = None):
+        ArgValidatorStr.__init__(self, name, required, default_value, None)
+        self.force_len = force_len
+    def _validate(self, value, name):
+        v = ArgValidatorStr._validate(self, value, name)
+        try:
+            addr = Util.mac_aton(v, self.force_len)
+        except MyError as e:
+            raise ValidationError(name, 'value "%s" is not a valid MAC address' % (value))
+        if not addr:
+            raise ValidationError(name, 'value "%s" is not a valid MAC address' % (value))
+        return Util.mac_ntoa(addr)
+
+class ArgValidatorIPAddr(ArgValidatorStr):
+    def __init__(self, name, family = None, required = False, default_value = None):
+        ArgValidatorStr.__init__(self, name, required, default_value, None)
+        self.family = family
+    def _validate(self, value, name):
+        v = ArgValidatorStr._validate(self, value, name)
+        try:
+            return Util.parse_address(v, self.family)
+        except:
+            raise ValidationError(name, 'value "%s" is not a valid IP%s address with prefix length' % (value, Util.addr_family_to_v(self.family)))
 
 class ArgValidator_DictIP(ArgValidatorDict):
     def __init__(self):

--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -606,12 +606,16 @@ class ArgValidatorMac(ArgValidatorStr):
             raise ValidationError(name, 'value "%s" is not a valid MAC address' % (value))
         return Util.mac_ntoa(addr)
 
-class ArgValidatorIPAddr(ArgValidatorStr):
+class ArgValidatorIPAddr(ArgValidator):
     def __init__(self, name, family = None, required = False, default_value = None):
-        ArgValidatorStr.__init__(self, name, required, default_value, None)
+        ArgValidator.__init__(self, name, required, default_value)
         self.family = family
     def _validate(self, value, name):
-        v = ArgValidatorStr._validate(self, value, name)
+        if not isinstance(value, Util.STRING_TYPE):
+            raise ValidationError(name, 'must be a string but is "%s"' % (value))
+        v = str(value)
+        if not v:
+            raise ValidationError(name, 'cannot be empty')
         try:
             return Util.parse_address(v, self.family)
         except:

--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -723,6 +723,7 @@ class ArgValidator_DictIP(ArgValidatorDict):
                     default_value = list,
                 ),
                 ArgValidatorBool('route_append_only'),
+                ArgValidatorBool('rule_append_only'),
                 ArgValidatorList('dns',
                     nested = ArgValidatorIP('dns[?]', plain_address=False),
                     default_value = list,
@@ -743,6 +744,7 @@ class ArgValidator_DictIP(ArgValidatorDict):
                 'address': [],
                 'route': [],
                 'route_append_only': False,
+                'rule_append_only': False,
                 'dns': [],
                 'dns_search': [],
             },
@@ -1246,6 +1248,10 @@ class IfcfgUtil:
             route6_file = cls._ifcfg_route_merge(route6,
                                                  ip['route_append_only'] and content_current,
                                                  content_current['route6'] if content_current else None)
+
+        if ip['rule_append_only'] and content_current:
+            rule4_file = content_current['rule']
+            rule6_file = content_current['rule6']
 
         for key in list(ifcfg.keys()):
             v = ifcfg[key]

--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -1045,7 +1045,7 @@ class IfcfgUtil:
         return s
 
     @classmethod
-    def ifcfg_create(cls, connections, idx, warn_fcn):
+    def ifcfg_create(cls, connections, idx, warn_fcn = lambda msg: None):
         connection = connections[idx]
         ip = connection['ip']
 

--- a/library/test_network_connections.py
+++ b/library/test_network_connections.py
@@ -242,6 +242,7 @@ class TestValidator(unittest.TestCase):
                         'dhcp4': True,
                         'address': [],
                         'route_append_only': False,
+                        'rule_append_only': False,
                         'route': [],
                         'route_metric6': None,
                         'dhcp4_send_hostname': None,
@@ -290,6 +291,7 @@ class TestValidator(unittest.TestCase):
                         'dhcp4': True,
                         'address': [],
                         'route_append_only': False,
+                        'rule_append_only': False,
                         'route': [],
                         'dns': [],
                         'dns_search': [],
@@ -360,6 +362,7 @@ class TestValidator(unittest.TestCase):
                             }
                         ],
                         'route_append_only': False,
+                        'rule_append_only': False,
                         'route': [],
                     },
                     'state': 'up',
@@ -415,6 +418,7 @@ class TestValidator(unittest.TestCase):
                             }
                         ],
                         'route_append_only': False,
+                        'rule_append_only': False,
                         'route': [],
                         'route_metric6': None,
                         'route_metric4': None,
@@ -466,6 +470,7 @@ class TestValidator(unittest.TestCase):
                             },
                         ],
                         'route_append_only': False,
+                        'rule_append_only': False,
                         'route': [
                             {
                                 'family': socket.AF_INET,
@@ -519,6 +524,7 @@ class TestValidator(unittest.TestCase):
                             },
                         ],
                         'route_append_only': False,
+                        'rule_append_only': False,
                         'route': [
                             {
                                 'network': '192.168.5.0',
@@ -547,6 +553,7 @@ class TestValidator(unittest.TestCase):
                         'dns': [],
                         'address': [],
                         'route_append_only': False,
+                        'rule_append_only': False,
                         'route': [],
                     },
                     'mac': None,
@@ -573,6 +580,7 @@ class TestValidator(unittest.TestCase):
                         'auto6': True,
                         'address': [],
                         'route_append_only': False,
+                        'rule_append_only': False,
                         'route': [],
                         'route_metric6': None,
                         'route_metric4': None,
@@ -637,6 +645,7 @@ class TestValidator(unittest.TestCase):
                         'dns': [],
                         'address': [],
                         'route_append_only': False,
+                        'rule_append_only': False,
                         'route': [],
                     },
                     'mac': None,
@@ -686,6 +695,7 @@ class TestValidator(unittest.TestCase):
                         'dns': [],
                         'address': [],
                         'route_append_only': False,
+                        'rule_append_only': False,
                         'route': [],
                     },
                     'mac': None,
@@ -731,6 +741,7 @@ class TestValidator(unittest.TestCase):
                     'ip': {
                         'address': [],
                         'route_append_only': False,
+                        'rule_append_only': False,
                         'route': [],
                         'auto6': True,
                         'dhcp4': True,
@@ -782,6 +793,7 @@ class TestValidator(unittest.TestCase):
                         'dhcp4': True,
                         'address': [],
                         'route_append_only': False,
+                        'rule_append_only': False,
                         'route': [],
                         'dns': [],
                         'dns_search': [ ],
@@ -826,6 +838,7 @@ class TestValidator(unittest.TestCase):
                         'dhcp4': True,
                         'address': [],
                         'route_append_only': False,
+                        'rule_append_only': False,
                         'route': [],
                         'dns': [],
                         'dns_search': [ ],
@@ -872,6 +885,7 @@ class TestValidator(unittest.TestCase):
                         'dhcp4': True,
                         'address': [],
                         'route_append_only': False,
+                        'rule_append_only': False,
                         'route': [
                             {
                                 'family': socket.AF_INET,
@@ -962,6 +976,7 @@ class TestValidator(unittest.TestCase):
                         'dhcp4': True,
                         'address': [],
                         'route_append_only': True,
+                        'rule_append_only': False,
                         'route': [
                             {
                                 'family': socket.AF_INET,
@@ -1011,6 +1026,7 @@ class TestValidator(unittest.TestCase):
                   'ip': {
                       'dns_search': [ 'aa', 'bb' ],
                       'route_append_only': True,
+                      'rule_append_only': False,
                       'route': [
                           {
                               'network': '192.168.45.0',

--- a/library/test_network_connections.py
+++ b/library/test_network_connections.py
@@ -33,6 +33,13 @@ class TestValidator(unittest.TestCase):
                           v.validate,
                           value)
 
+    def do_connections_check_invalid(self, input_connections):
+        self.assertValidationError(n.AnsibleUtil.ARGS_CONNECTIONS, input_connections)
+
+    def do_connections_validate(self, expected_connections, input_connections):
+        connections = n.AnsibleUtil.ARGS_CONNECTIONS.validate(input_connections)
+        self.assertEqual(expected_connections, connections)
+
     def test_validate_str(self):
 
         v = n.ArgValidatorStr('state')
@@ -127,12 +134,12 @@ class TestValidator(unittest.TestCase):
 
         self.maxDiff = None
 
-        self.assertEqual(
+        self.do_connections_validate(
             [],
-            n.AnsibleUtil.ARGS_CONNECTIONS.validate([]),
+            [],
         )
 
-        self.assertEqual(
+        self.do_connections_validate(
             [
                 {
                     'name': '5',
@@ -171,14 +178,14 @@ class TestValidator(unittest.TestCase):
                     'ignore_errors': None,
                 }
             ],
-            n.AnsibleUtil.ARGS_CONNECTIONS.validate([
+            [
                 { 'name': '5',
                   'type': 'ethernet',
                 },
                 { 'name': '5' }
-            ]),
+            ],
         )
-        self.assertEqual(
+        self.do_connections_validate(
             [
                 {
                     'name': '5',
@@ -212,18 +219,17 @@ class TestValidator(unittest.TestCase):
                     'infiniband_transport_mode': None,
                 },
             ],
-            n.AnsibleUtil.ARGS_CONNECTIONS.validate([
+            [
                 { 'name': '5',
                   'state': 'up',
                   'type': 'ethernet',
                 },
-            ]),
+            ],
         )
 
-        self.assertValidationError(n.AnsibleUtil.ARGS_CONNECTIONS,
-                                   [ { 'name': 'a', 'autoconnect': True }])
+        self.do_connections_check_invalid([ { 'name': 'a', 'autoconnect': True }])
 
-        self.assertEqual(
+        self.do_connections_validate(
             [
                 {
                     'name': '5',
@@ -231,15 +237,15 @@ class TestValidator(unittest.TestCase):
                     'ignore_errors': None,
                 }
             ],
-            n.AnsibleUtil.ARGS_CONNECTIONS.validate([
+            [
                 {
                     'name': '5',
                     'state': 'absent',
                 }
-            ]),
+            ],
         )
 
-        self.assertEqual(
+        self.do_connections_validate(
             [
                 {
                     'autoconnect': True,
@@ -279,7 +285,7 @@ class TestValidator(unittest.TestCase):
                     'infiniband_transport_mode': None,
                 },
             ],
-            n.AnsibleUtil.ARGS_CONNECTIONS.validate([
+            [
                 {
                     'name': 'prod1',
                     'state': 'up',
@@ -291,10 +297,10 @@ class TestValidator(unittest.TestCase):
                         'address': '192.168.174.5/24',
                     }
                 }
-            ]),
+            ],
         )
 
-        self.assertEqual(
+        self.do_connections_validate(
             [
                 {
                     'autoconnect': True,
@@ -381,7 +387,7 @@ class TestValidator(unittest.TestCase):
                     'infiniband_transport_mode': None,
                 }
             ],
-            n.AnsibleUtil.ARGS_CONNECTIONS.validate([
+            [
                 {
                     'name': 'prod1',
                     'state': 'up',
@@ -409,10 +415,10 @@ class TestValidator(unittest.TestCase):
                         ],
                     }
                 }
-            ]),
+            ],
         )
 
-        self.assertEqual(
+        self.do_connections_validate(
             [
                 {
                     'autoconnect': True,
@@ -477,7 +483,7 @@ class TestValidator(unittest.TestCase):
                     'infiniband_transport_mode': None,
                 }
             ],
-            n.AnsibleUtil.ARGS_CONNECTIONS.validate([
+            [
                 {
                     'name': 'prod2',
                     'state': 'up',
@@ -495,10 +501,10 @@ class TestValidator(unittest.TestCase):
                     'interface_name': 'eth1',
                     'master': 'prod2',
                 }
-            ]),
+            ],
         )
 
-        self.assertEqual(
+        self.do_connections_validate(
             [
                 {
                     'autoconnect': True,
@@ -536,16 +542,16 @@ class TestValidator(unittest.TestCase):
                     'infiniband_transport_mode': None,
                 },
             ],
-            n.AnsibleUtil.ARGS_CONNECTIONS.validate([
+            [
                 {
                     'name': 'bond1',
                     'state': 'up',
                     'type': 'bond',
                 },
-            ]),
+            ],
         )
 
-        self.assertEqual(
+        self.do_connections_validate(
             [
                 {
                     'autoconnect': True,
@@ -583,7 +589,7 @@ class TestValidator(unittest.TestCase):
                     'infiniband_transport_mode': None,
                 },
             ],
-            n.AnsibleUtil.ARGS_CONNECTIONS.validate([
+            [
                 {
                     'name': 'bond1',
                     'state': 'up',
@@ -592,15 +598,13 @@ class TestValidator(unittest.TestCase):
                         'mode': 'active-backup',
                     },
                 },
-            ]),
+            ],
         )
 
-        self.assertValidationError(n.AnsibleUtil.ARGS_CONNECTIONS,
-                                   [ { } ])
-        self.assertValidationError(n.AnsibleUtil.ARGS_CONNECTIONS,
-                                   [ { 'name': 'b', 'xxx': 5 } ])
+        self.do_connections_check_invalid([ { } ])
+        self.do_connections_check_invalid([ { 'name': 'b', 'xxx': 5 } ])
 
-        self.assertEqual(
+        self.do_connections_validate(
             [
                 {
                     'autoconnect': True,
@@ -632,16 +636,16 @@ class TestValidator(unittest.TestCase):
                     'infiniband_transport_mode': None,
                 },
             ],
-            n.AnsibleUtil.ARGS_CONNECTIONS.validate([
+            [
                 {
                     'name': '5',
                     'type': 'ethernet',
                     'mac': 'AA:bb:cC:DD:ee:FF',
                 }
-            ]),
+            ],
         )
 
-        self.assertEqual(
+        self.do_connections_validate(
             [
                 {
                     'name': '5',
@@ -675,15 +679,15 @@ class TestValidator(unittest.TestCase):
                     'infiniband_transport_mode': None,
                 },
             ],
-            n.AnsibleUtil.ARGS_CONNECTIONS.validate([
+            [
                 { 'name': '5',
                   'state': 'up',
                   'type': 'ethernet',
                 },
-            ]),
+            ],
         )
 
-        self.assertEqual(
+        self.do_connections_validate(
             [
                 {
                     'name': '5',
@@ -717,17 +721,17 @@ class TestValidator(unittest.TestCase):
                     'infiniband_transport_mode': None,
                 },
             ],
-            n.AnsibleUtil.ARGS_CONNECTIONS.validate([
+            [
                 { 'name': '5',
                   'state': 'up',
                   'type': 'ethernet',
                   'ip': {
                   },
                 },
-            ]),
+            ],
         )
 
-        self.assertEqual(
+        self.do_connections_validate(
             [
                 {
                     'name': '5',
@@ -761,7 +765,7 @@ class TestValidator(unittest.TestCase):
                     'infiniband_transport_mode': None,
                 },
             ],
-            n.AnsibleUtil.ARGS_CONNECTIONS.validate([
+            [
                 { 'name': '5',
                   'state': 'up',
                   'type': 'ethernet',
@@ -769,12 +773,10 @@ class TestValidator(unittest.TestCase):
                       'dns_search': [ 'aa', 'bb' ],
                   },
                 },
-            ]),
+            ],
         )
 
-
-        self.assertValidationError(n.AnsibleUtil.ARGS_CONNECTIONS,
-                                   [ { 'name': 'b', 'type': 'ethernet', 'mac': 'aa:b' } ])
+        self.do_connections_check_invalid([ { 'name': 'b', 'type': 'ethernet', 'mac': 'aa:b' } ])
 
 @my_test_skipIf(nmutil is None, 'no support for NM (libnm via pygobject)')
 class TestNM(unittest.TestCase):

--- a/library/test_network_connections.py
+++ b/library/test_network_connections.py
@@ -3,6 +3,7 @@
 import sys
 import os
 import unittest
+import socket
 
 sys.path.insert(1, os.path.dirname(os.path.abspath(__file__)))
 
@@ -257,7 +258,7 @@ class TestValidator(unittest.TestCase):
                         'address': [
                             {
                                 'prefix': 24,
-                                'family': 2,
+                                'family': socket.AF_INET,
                                 'address': '192.168.174.5'
                             }
                         ]
@@ -305,12 +306,12 @@ class TestValidator(unittest.TestCase):
                         'address': [
                             {
                                 'prefix': 24,
-                                'family': 2,
+                                'family': socket.AF_INET,
                                 'address': '192.168.176.5'
                             },
                             {
                                 'prefix': 24,
-                                'family': 2,
+                                'family': socket.AF_INET,
                                 'address': '192.168.177.5'
                             }
                         ],
@@ -349,14 +350,19 @@ class TestValidator(unittest.TestCase):
                         'dhcp4_send_hostname': None,
                         'gateway6': None,
                         'gateway4': None,
-                        'auto6': True,
+                        'auto6': False,
                         'dns': [],
                         'address': [
                             {
                                 'prefix': 24,
-                                'family': 2,
+                                'family': socket.AF_INET,
                                 'address': '192.168.174.5'
-                            }
+                            },
+                            {
+                                'prefix': 65,
+                                'family': socket.AF_INET6,
+                                'address': 'a:b:c::6',
+                            },
                         ]
                     },
                     'mac': None,
@@ -394,7 +400,13 @@ class TestValidator(unittest.TestCase):
                     'parent': 'prod1',
                     'vlan_id': '100',
                     'ip': {
-                        'address': [ '192.168.174.5/24' ],
+                        'address': [
+                            '192.168.174.5/24',
+                            {
+                                'address': 'a:b:c::6',
+                                'prefix': 65,
+                            },
+                        ],
                     }
                 }
             ]),

--- a/library/test_network_connections.py
+++ b/library/test_network_connections.py
@@ -256,7 +256,6 @@ class TestValidator(unittest.TestCase):
                         'dns': [],
                         'address': [
                             {
-                                'is_v4': True,
                                 'prefix': 24,
                                 'family': 2,
                                 'address': '192.168.174.5'
@@ -305,13 +304,11 @@ class TestValidator(unittest.TestCase):
                         'auto6': True,
                         'address': [
                             {
-                                'is_v4': True,
                                 'prefix': 24,
                                 'family': 2,
                                 'address': '192.168.176.5'
                             },
                             {
-                                'is_v4': True,
                                 'prefix': 24,
                                 'family': 2,
                                 'address': '192.168.177.5'
@@ -356,7 +353,6 @@ class TestValidator(unittest.TestCase):
                         'dns': [],
                         'address': [
                             {
-                                'is_v4': True,
                                 'prefix': 24,
                                 'family': 2,
                                 'address': '192.168.174.5'


### PR DESCRIPTION
Currently, only "dest/prefix,gateway,metric" are supported.

There is an option `route_append_only`, to only extend the pre-existing configuration by adding further routes. I think this setting is wrong in principle, because you should better define the entire configuration in the playbook, not just parts and not extend on the pre-existing configuration. It makes the outcome of the run dependent on pre-existing configuration. But it is here on request.