### PR TITLE
th/ansible_independent

### DIFF
--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -2037,11 +2037,6 @@ class _AnsibleUtil(RunEnvironment):
             changed = True
         self.run_results[idx]['changed'] = bool(changed)
 
-    def run_results_rc(self, idx, rc, msg):
-        assert(idx >= 0 and idx < len(self.run_results) - 1)
-        self.run_results[idx]['rc'].append((rc, msg))
-        self.log(idx, LogLevel.INFO, 'command: %s (rc=%s)' % (msg, rc))
-
     def log(self, idx, severity, msg, warn_traceback = False, force_fail = False):
         self._log_idx += 1
         if idx == -1:

--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -2004,21 +2004,15 @@ class AnsibleUtil(RunEnvironment):
 
     def __init__(self):
         RunEnvironment.__init__(self)
-        self._module = None
         self._run_results = []
         self._log_idx = 0
 
-    @property
-    def module(self):
-        module = self._module
-        if module is None:
-            from ansible.module_utils.basic import AnsibleModule
-            module = AnsibleModule(
-                argument_spec = self.ARGS,
-                supports_check_mode = True,
-            )
-            self._module = module
-        return module
+        from ansible.module_utils.basic import AnsibleModule
+        module = AnsibleModule(
+            argument_spec = self.ARGS,
+            supports_check_mode = True,
+        )
+        self.module = module
 
     def run_command(self, argv, encoding = None):
         return self.module.run_command(argv, encoding = encoding)
@@ -2681,9 +2675,9 @@ class Cmd_initscripts(Cmd):
 ###############################################################################
 
 if __name__ == '__main__':
-    ansible_util = AnsibleUtil()
     connections = None
     cmd = None
+    ansible_util = AnsibleUtil()
     try:
         params = ansible_util.module.params
         cmd = Cmd.create(params['provider'],

--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -1993,7 +1993,7 @@ class RunEnvironment:
         self._check_mode_changed(c, check_mode, connections)
 
 
-class AnsibleUtil(RunEnvironment):
+class RunEnvironmentAnsible(RunEnvironment):
 
     ARGS = {
         'ignore_errors':  { 'required': False, 'default': False, 'type': 'str' },
@@ -2677,22 +2677,22 @@ class Cmd_initscripts(Cmd):
 if __name__ == '__main__':
     connections = None
     cmd = None
-    ansible_util = AnsibleUtil()
+    run_env_ansible = RunEnvironmentAnsible()
     try:
-        params = ansible_util.module.params
+        params = run_env_ansible.module.params
         cmd = Cmd.create(params['provider'],
-                         run_env = ansible_util,
+                         run_env = run_env_ansible,
                          connections_unvalidated = params['connections'],
                          connection_validator = ArgValidator_ListConnections(),
-                         is_check_mode = ansible_util.module.check_mode,
+                         is_check_mode = run_env_ansible.module.check_mode,
                          ignore_errors = params['ignore_errors'],
                          force_state_change = params['force_state_change'])
         connections = cmd.connections
         cmd.run()
     except Exception as e:
-        ansible_util.fail_json(connections,
-                               'fatal error: %s' % (e),
-                               changed = (cmd is not None and cmd.is_changed),
-                               warn_traceback = not isinstance(e, MyError))
-    ansible_util.exit_json(connections,
-                           changed = (cmd is not None and cmd.is_changed))
+        run_env_ansible.fail_json(connections,
+                                  'fatal error: %s' % (e),
+                                  changed = (cmd is not None and cmd.is_changed),
+                                  warn_traceback = not isinstance(e, MyError))
+    run_env_ansible.exit_json(connections,
+                              changed = (cmd is not None and cmd.is_changed))

--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -1965,6 +1965,9 @@ class RunEnvironment:
     def log(self, idx, severity, msg, warn_traceback = False, force_fail = False):
         raise NotImplementedError()
 
+    def run_command(self, argv, encoding = None):
+        raise NotImplementedError()
+
 class _AnsibleUtil(RunEnvironment):
 
     ARGS = {
@@ -1992,6 +1995,9 @@ class _AnsibleUtil(RunEnvironment):
             )
             self._module = module
         return module
+
+    def run_command(self, argv, encoding = None):
+        return self.module.run_command(argv, encoding = encoding)
 
     @property
     def params(self):
@@ -2113,6 +2119,9 @@ class Cmd:
         self._force_state_change = Util.boolean(force_state_change)
 
         self._check_mode = CheckMode.PREPARE
+
+    def run_command(argv, encoding = None):
+        return self.run_env.run_command(argv, encoding = encoding)
 
     def log_debug(self, idx, msg):
         self.log(idx, LogLevel.DEBUG, msg)
@@ -2596,7 +2605,7 @@ class Cmd_initscripts(Cmd):
             cmd = 'ifdown'
 
         if self.check_mode == CheckMode.REAL_RUN:
-            rc, out, err = AnsibleUtil.module.run_command([cmd, name], encoding=None)
+            rc, out, err = self.run_env.run_command([cmd, name])
             self.log_info(idx, 'call `%s %s`: rc=%d, out="%s", err="%s"' % (cmd, name, rc, out, err))
             if rc != 0:
                 self.log_error(idx, 'call `%s %s` failed with exit status %d' % (cmd, name, rc))

--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -2013,8 +2013,7 @@ class _AnsibleUtil(RunEnvironment):
             try:
                 c = ArgValidator_ListConnections().validate(self.params['connections'])
             except ValidationError as e:
-                self.fail_json('configuration error: %s' % (e),
-                               warn_traceback = False)
+                raise MyError('configuration error: %s' % (e))
             self._connections = c
         return c
 
@@ -2290,7 +2289,7 @@ class Cmd_nm(Cmd):
             try:
                 nmclient = Util.NM().Client.new(None)
             except Exception as e:
-                AnsibleUtil.fail_json('failure loading libnm library: %s' % (e))
+                raise MyError('failure loading libnm library: %s' % (e))
             self._nmutil = NMUtil(nmclient)
         return self._nmutil
 

--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -2187,13 +2187,12 @@ AnsibleUtil = _AnsibleUtil()
 class Cmd:
 
     @staticmethod
-    def create():
-        provider = AnsibleUtil.params['provider']
+    def create(provider):
         if provider == 'nm':
             return Cmd_nm()
         elif provider == 'initscripts':
             return Cmd_initscripts()
-        AnsibleUtil.fail_json('unsupported provider %s' % (provider))
+        raise MyError('unsupported provider %s' % (provider))
 
     def run(self):
         for idx, connection in enumerate(AnsibleUtil.connections):
@@ -2601,8 +2600,8 @@ class Cmd_initscripts(Cmd):
 
 if __name__ == '__main__':
     try:
-        Cmd.create().run()
+        Cmd.create(AnsibleUtil.params['provider']).run()
     except Exception as e:
         AnsibleUtil.fail_json('fatal error: %s' % (e),
-                              warn_traceback = True)
+                              warn_traceback = not isinstance(e, MyError))
     AnsibleUtil.exit_json()

--- a/library/test_network_connections.py
+++ b/library/test_network_connections.py
@@ -40,6 +40,8 @@ def pprint(msg, obj):
     if nmutil is not None and isinstance(obj, NM.Connection):
         obj.dump()
 
+ARGS_CONNECTIONS = n.ArgValidator_ListConnections()
+
 class TestValidator(unittest.TestCase):
 
     def assertValidationError(self, v, value):
@@ -62,12 +64,12 @@ class TestValidator(unittest.TestCase):
         self.assertEqual(route_list_exp, route_list_new)
 
     def do_connections_check_invalid(self, input_connections):
-        self.assertValidationError(n.AnsibleUtil.ARGS_CONNECTIONS, input_connections)
+        self.assertValidationError(ARGS_CONNECTIONS, input_connections)
 
     def do_connections_validate_nm(self, input_connections, **kwargs):
         if not nmutil:
             return
-        connections = n.AnsibleUtil.ARGS_CONNECTIONS.validate(input_connections)
+        connections = ARGS_CONNECTIONS.validate(input_connections)
         for connection in connections:
             if 'type' in connection:
                 connection['nm.exists'] = False
@@ -75,7 +77,7 @@ class TestValidator(unittest.TestCase):
         mode = n.ArgValidator_ListConnections.VALIDATE_ONE_MODE_INITSCRIPTS
         for idx, connection in enumerate(connections):
             try:
-                n.AnsibleUtil.ARGS_CONNECTIONS.validate_connection_one(mode, connections, idx)
+                ARGS_CONNECTIONS.validate_connection_one(mode, connections, idx)
             except n.ValidationError as e:
                 continue
             if 'type' in connection:
@@ -104,10 +106,10 @@ class TestValidator(unittest.TestCase):
 
     def do_connections_validate_ifcfg(self, input_connections, **kwargs):
         mode = n.ArgValidator_ListConnections.VALIDATE_ONE_MODE_INITSCRIPTS
-        connections = n.AnsibleUtil.ARGS_CONNECTIONS.validate(input_connections)
+        connections = ARGS_CONNECTIONS.validate(input_connections)
         for idx, connection in enumerate(connections):
             try:
-                n.AnsibleUtil.ARGS_CONNECTIONS.validate_connection_one(mode, connections, idx)
+                ARGS_CONNECTIONS.validate_connection_one(mode, connections, idx)
             except n.ValidationError as e:
                 continue
             if 'type' in connection:
@@ -122,7 +124,7 @@ class TestValidator(unittest.TestCase):
 
 
     def do_connections_validate(self, expected_connections, input_connections, **kwargs):
-        connections = n.AnsibleUtil.ARGS_CONNECTIONS.validate(input_connections)
+        connections = ARGS_CONNECTIONS.validate(input_connections)
         self.assertEqual(expected_connections, connections)
         self.do_connections_validate_nm(input_connections, **kwargs)
         self.do_connections_validate_ifcfg(input_connections, **kwargs)


### PR DESCRIPTION
Refactor the module, to make it mostly independent of the ansible runtime.

The module is just one large python script. Ansible will execute it and communicated with it via stdout/stdin.

However, most of the stuff that the script does, is independent of ansible or how it is called.

Refactor the code, so that the parts that require the ansible environment can be replaced. This way, one could import the code in another python application, or we could run it from the command line and feed our own input format.