### PR TITLE
add macvlan support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The role can be used to configure:
 - Bridge interfaces
 - Bonded interfaces
 - VLAN  interfaces
+- MacVLAN interfaces
 - IP configuration
 
 General
@@ -361,6 +362,34 @@ network_connections:
 ```
 
 Like for `master`, the `parent` references the connection profile in the ansible
+role.
+
+### `type: macvlan`
+
+MACVLANs also work:
+
+```yaml
+network_connections:
+  - name: eth0-profile
+    type: ethernet
+    interface_name: eth0
+    ip:
+      address:
+        - 192.168.0.1/24
+
+  - name: veth0
+    type: macvlan
+    parent: eth0-profile
+    macvlan:
+      mode: bridge
+      promiscuous: True
+      tap: False
+    ip:
+      address:
+        - 192.168.1.1/24
+```
+
+Like for `master` and `vlan`, the `parent` references the connection profile in the ansible
 role.
 
 ### `network_provider`

--- a/examples/macvlan.yml
+++ b/examples/macvlan.yml
@@ -1,0 +1,26 @@
+---
+- hosts: network-test
+  vars:
+    network_connections:
+
+      - name: eth0
+        type: ethernet
+        interface_name: eth0
+        ip:
+          address:
+            - 192.168.0.1/24
+
+      # Create a virtual ethernet card bound to eth0
+      - name: veth0
+        type: macvlan
+        parent: eth0
+        macvlan:
+          mode: bridge
+          promiscuous: True
+          tap: False
+        ip:
+          address:
+            - 192.168.1.1/24
+
+  roles:
+    - network

--- a/library/test_network_connections.py
+++ b/library/test_network_connections.py
@@ -796,7 +796,6 @@ class TestValidator(unittest.TestCase):
                     'type': 'macvlan',
                     'macvlan': {
                         'mode' : 'bridge',
-                        'mode_id': 2,
                         'promiscuous': True,
                         'tap': False,
                     },
@@ -848,7 +847,6 @@ class TestValidator(unittest.TestCase):
                     'type': 'macvlan',
                     'macvlan': {
                         'mode' : 'passthru',
-                        'mode_id': 4,
                         'promiscuous': False,
                         'tap': True,
                     },
@@ -877,7 +875,6 @@ class TestValidator(unittest.TestCase):
                     'interface_name': 'veth0',
                     'macvlan': {
                         'mode': 'bridge',
-                        'mode_id': 2,
                         'promiscuous': True,
                         'tap': False,
                     },
@@ -901,7 +898,6 @@ class TestValidator(unittest.TestCase):
                     'interface_name': 'veth1',
                     'macvlan': {
                         'mode': 'passthru',
-                        'mode_id': 4,
                         'promiscuous': False,
                         'tap': True
                     },

--- a/library/test_network_connections.py
+++ b/library/test_network_connections.py
@@ -709,6 +709,222 @@ class TestValidator(unittest.TestCase):
             [
                 {
                     'autoconnect': True,
+                    'name': 'eth0-parent',
+                    'parent': None,
+                    'ip': {
+                        'dhcp4': False,
+                        'auto6': False,
+                        'address': [
+                            {
+                                'prefix': 24,
+                                'family': socket.AF_INET,
+                                'address': '192.168.122.3'
+                            },
+                        ],
+                        'route_append_only': False,
+                        'rule_append_only': False,
+                        'route': [],
+                        'route_metric6': None,
+                        'route_metric4': None,
+                        'dns_search': [],
+                        'dhcp4_send_hostname': None,
+                        'gateway6': None,
+                        'gateway4': None,
+                        'dns': []
+                    },
+                    'ethernet': {
+                        'autoneg': None,
+                        'duplex': None,
+                        'speed': 0,
+                    },
+                    'state': 'up',
+                    'mtu': 1450,
+                    'check_iface_exists': True,
+                    'force_state_change': None,
+                    'mac': '33:24:10:24:2f:b9',
+                    'zone': None,
+                    'master': None,
+                    'ignore_errors': None,
+                    'interface_name': "eth0",
+                    'type': 'ethernet',
+                    'slave_type': None,
+                    'wait': None,
+                },
+                {
+                    'autoconnect': True,
+                    'name': 'veth0.0',
+                    'parent': 'eth0-parent',
+                    'ip': {
+                        'dhcp4': False,
+                        'route_metric6': None,
+                        'route_metric4': None,
+                        'dns_search': [],
+                        'dhcp4_send_hostname': None,
+                        'gateway6': None,
+                        'gateway4': None,
+                        'auto6': False,
+                        'dns': [],
+                        'address': [
+                            {
+                                'prefix': 24,
+                                'family': socket.AF_INET,
+                                'address': '192.168.244.1'
+                            },
+                        ],
+                        'route_append_only': False,
+                        'rule_append_only': False,
+                        'route': [
+                            {
+                                'family': socket.AF_INET,
+                                'network': '192.168.244.0',
+                                'prefix': 24,
+                                'gateway': None,
+                                'metric': -1,
+                            },
+                        ],
+                    },
+                    'mac': None,
+                    'mtu': None,
+                    'zone': None,
+                    'check_iface_exists': True,
+                    'force_state_change': None,
+                    'state': 'up',
+                    'master': None,
+                    'slave_type': None,
+                    'ignore_errors': None,
+                    'interface_name': 'veth0',
+                    'type': 'macvlan',
+                    'macvlan': {
+                        'mode' : 'bridge',
+                        'mode_id': 2,
+                        'promiscuous': True,
+                        'tap': False,
+                    },
+                    'wait': None,
+                },
+                {
+                    'autoconnect': True,
+                    'name': 'veth0.1',
+                    'parent': 'eth0-parent',
+                    'ip': {
+                        'dhcp4': False,
+                        'route_metric6': None,
+                        'route_metric4': None,
+                        'dns_search': [],
+                        'dhcp4_send_hostname': None,
+                        'gateway6': None,
+                        'gateway4': None,
+                        'auto6': False,
+                        'dns': [],
+                        'address': [
+                            {
+                                'prefix': 24,
+                                'family': socket.AF_INET,
+                                'address': '192.168.245.7'
+                            },
+                        ],
+                        'route_append_only': False,
+                        'rule_append_only': False,
+                        'route': [
+                            {
+                                'family': socket.AF_INET,
+                                'network': '192.168.245.0',
+                                'prefix': 24,
+                                'gateway': None,
+                                'metric': -1,
+                            },
+                        ],
+                    },
+                    'mac': None,
+                    'mtu': None,
+                    'zone': None,
+                    'check_iface_exists': True,
+                    'force_state_change': None,
+                    'state': 'up',
+                    'master': None,
+                    'slave_type': None,
+                    'ignore_errors': None,
+                    'interface_name': 'veth1',
+                    'type': 'macvlan',
+                    'macvlan': {
+                        'mode' : 'passthru',
+                        'mode_id': 4,
+                        'promiscuous': False,
+                        'tap': True,
+                    },
+                    'wait': None,
+                }
+            ],
+            [
+                {
+                    'name': 'eth0-parent',
+                    'state': 'up',
+                    'type': 'ethernet',
+                    'autoconnect': 'yes',
+                    'interface_name': 'eth0',
+                    'mac': '33:24:10:24:2f:b9',
+                    'mtu': 1450,
+                    'ip': {
+                        'address': '192.168.122.3/24',
+                        'auto6': False
+                    },
+                },
+                {
+                    'name': 'veth0.0',
+                    'state': 'up',
+                    'type': 'macvlan',
+                    'parent': 'eth0-parent',
+                    'interface_name': 'veth0',
+                    'macvlan': {
+                        'mode': 'bridge',
+                        'mode_id': 2,
+                        'promiscuous': True,
+                        'tap': False,
+                    },
+                    'ip': {
+                        'address': '192.168.244.1/24',
+                        'auto6': False,
+                        'route_append_only': False,
+                        'rule_append_only': False,
+                        'route': [
+                            {
+                                'network': '192.168.244.0',
+                            },
+                        ],
+                    }
+                },
+                {
+                    'name': 'veth0.1',
+                    'state': 'up',
+                    'type': 'macvlan',
+                    'parent': 'eth0-parent',
+                    'interface_name': 'veth1',
+                    'macvlan': {
+                        'mode': 'passthru',
+                        'mode_id': 4,
+                        'promiscuous': False,
+                        'tap': True
+                    },
+                    'ip': {
+                        'address': '192.168.245.7/24',
+                        'auto6': False,
+                        'route_append_only': False,
+                        'rule_append_only': False,
+                        'route': [
+                            {
+                                'network': '192.168.245.0',
+                            },
+                        ],
+                    }
+                }
+            ],
+        )
+
+
+        self.do_connections_validate(
+            [
+                {
+                    'autoconnect': True,
                     'name': 'prod2',
                     'parent': None,
                     'ip': {


### PR DESCRIPTION
Here is a first version for macvlan support.

Please note:
The networkmanager library expects an integer to identify the macvlan mode, not the name. The mode name is therefore converted to the mode_id in ArgValidator_DictMacvlan . But to make the unit tests work, this also meant that that the user can also supply the mode_id. (I first overwrote result['mode'] in _validate_post, but then no tests worked any more).

Also, the unit tests fail during ifcfg_create, because I didn't see how to abort in run_prepare. I think the best way is to change do_connections_validate() to not run do_connections_validate_ifcfg() when no initscripts_dict_expected is given.