### PR TITLE
Inconsistent behavior for bridges on RHEL6 and RHEL7

### DIFF
--- a/tests/tests_bridge.yml
+++ b/tests/tests_bridge.yml
@@ -49,7 +49,6 @@
     profile: "{{ interface }}"
     task: tasks/assert-profile_absent.yml
 
-# FIXME: Devices might still be left when profile is absent
-#- import_playbook: run-tasks.yml
-#  vars:
-#    task: tasks/assert-device_absent.yml
+- import_playbook: run-tasks.yml
+  vars:
+    task: tasks/assert-device_absent.yml


### PR DESCRIPTION
This fails on RHEL6 and is related to #35 iirc.