### PR TITLE
moved default-nm.yml to default.yml

### DIFF
--- a/vars/default-nm.yml
+++ b/vars/default-nm.yml
@@ -1,2 +1,0 @@
-# SPDX-License-Identifier: BSD-3-Clause
-network_provider_default: nm

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,1 +1,2 @@
-default-nm.yml
+# SPDX-License-Identifier: BSD-3-Clause
+network_provider_default: nm


### PR DESCRIPTION
You are not able to include a variable file in another variable file. Ansible will exit with an error. Also there seems to be no need to add two different default files if one default file is including the other one.

The ansible error: "message": "/roles/network/vars/default.yml must be stored as a dictionary/hash"
