### PR TITLE
Print network provider early

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,10 @@
 - name: Check which packages are installed
   package_facts:
 
+- name: Print network provider
+  debug:
+    msg: "Using network provider: {{ network_provider }}"
+
 # Depending on the plugins, checking installed packages might be slow
 # for example subscription manager might slow this down
 # Therefore install packages only when rpm does not find them
@@ -22,10 +26,6 @@
       name: "{{ network_service_name }}"
       state: started
       enabled: yes
-
-- name: Print network provider
-  debug:
-    msg: "Using network provider: {{ network_provider }}"
 
 - name: Configure networking connection profiles
   network_connections:


### PR DESCRIPTION
The list of packages to install depends on the network provider, so
print it out early.