### PR TITLE
tasks: Do not log full service facts

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,7 @@
 # get service facts, used in defaults/main.yml
 - name: Check which services are running
   service_facts:
+  no_log: true
 
 # needed for ansible_facts.packages
 - name: Check which packages are installed


### PR DESCRIPTION
The service facts create too much noise in test logs, therefore hide
them.