### PR TITLE
Configure Molecule in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ matrix:
     - python: 2.6
       dist: trusty
     - python: 2.7
-    - python: 3.6
+    - python: 3.5
       env: aptpkgs=python3-selinux
+    - python: 3.6
     - python: 3.7
     - python: 3.7-dev
     - python: 3.8-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,17 @@ matrix:
       dist: trusty
     - python: 2.7
     - python: 3.6
+      env: aptpkgs=python3-selinux
     - python: 3.7
     - python: 3.7-dev
     - python: 3.8-dev
     # - python: nightly
+
+services:
+  - docker
+
+before_install:
+  - if [ -n "${aptpkgs}" ]; then sudo apt-get install -y python3-selinux; fi
 
 install:
   - pip install tox tox-travis

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -1,0 +1,14 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,38 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  options:
+    config-file: molecule/default/yamllint.yml
+platforms:
+  - name: centos-6
+    image: linuxsystemroles/centos-6
+    privileged: true
+  - name: centos-7
+    image: linuxsystemroles/centos-7
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+provisioner:
+  name: ansible
+  log: true
+  lint:
+    name: ansible-lint
+  playbooks:
+    converge: ../../tests/tests_default.yml
+scenario:
+  name: default
+  test_sequence:
+    - destroy
+    - create
+    - converge
+    - idempotence
+    - check
+    - destroy
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/default/yamllint.yml
+++ b/molecule/default/yamllint.yml
@@ -1,0 +1,12 @@
+---
+extends: default
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  truthy: disable
+  document-start: disable

--- a/tox.ini
+++ b/tox.ini
@@ -169,6 +169,7 @@ max-line-length = 88
 python =
   2.6: py26
   2.7: py27,coveralls,flake8,pylint
-  3.6: py36,black,ensure_non_running_provider,molecule_lint,molecule_syntax,molecule_test
+  3.5: molecule_lint,molecule_syntax,molecule_test
+  3.6: py36,black,ensure_non_running_provider
   3.7: py37
   3.8: py38

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,11 @@ deps =
     molecule_{lint,syntax,test}: docker
     molecule_{lint,syntax,test}: jmespath
     molecule_{lint,syntax,test}: molecule
-    molecule_{lint,syntax,test}: selinux
+    # The selinux pypi shim does not work with Ubuntu (as used by Travis), yet.
+    # Therefore use a fork with Ubuntu support. This can be changed once the
+    # update is available on PyPi.
+    # molecule_{lint,syntax,test}: selinux
+    molecule_{lint,syntax,test}: git+https://github.com/tyll/selinux-pypi-shim@fulllocation
 
 [base]
 passenv = *

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,16 @@ skipsdist = true
 skip_missing_interpreters = True
 
 [testenv]
-basepython = python2.7
+basepython = python3
 deps =
     py{26,27,36,37,38}: pytest-cov
     py{27,36,37,38}: pytest>=3.5.1
     py{26,27}: mock
     py26: pytest
+    molecule_{lint,syntax,test}: docker
+    molecule_{lint,syntax,test}: jmespath
+    molecule_{lint,syntax,test}: molecule
+    molecule_{lint,syntax,test}: selinux
 
 [base]
 passenv = *
@@ -21,17 +25,16 @@ covtarget = {toxinidir}/library --cov {toxinidir}/module_utils
 pytesttarget = .
 
 [testenv:black]
-basepython = python3.6
 deps = black
 
 commands = black --check --diff --include "^[^.].*\.py$" .
 
 [testenv:py26]
+basepython = python2.6
 passenv = {[base]passenv}
 setenv =
     {[base]setenv}
 changedir = {[base]changedir}
-basepython = python2.6
 commands =
     pytest \
         --durations=5 \
@@ -41,11 +44,11 @@ commands =
         {[base]pytesttarget}
 
 [testenv:py27]
+basepython = python2.7
 passenv = {[base]passenv}
 setenv =
     {[base]setenv}
 changedir = {[base]changedir}
-basepython = python2.7
 commands =
     pytest \
         --durations=5 \
@@ -55,11 +58,11 @@ commands =
         {[base]pytesttarget}
 
 [testenv:py36]
+basepython = python3.6
 passenv = {[base]passenv}
 setenv =
     {[base]setenv}
 changedir = {[base]changedir}
-basepython = python3.6
 commands =
     pytest \
         --durations=5 \
@@ -69,11 +72,11 @@ commands =
         {[base]pytesttarget}
 
 [testenv:py37]
+basepython = python3.7
 passenv = {[base]passenv}
 setenv =
     {[base]setenv}
 changedir = {[base]changedir}
-basepython = python3.7
 commands =
     pytest \
         --durations=5 \
@@ -112,6 +115,7 @@ commands =
         tests/test_network_connections.py
 
 [testenv:flake8]
+basepython = python2.7
 deps =
     flake8>=3.5
 whitelist_externals = flake8
@@ -120,6 +124,7 @@ commands=
         .
 
 [testenv:coveralls]
+basepython = python2.7
 passenv = TRAVIS TRAVIS_*
 deps =
     coveralls
@@ -128,11 +133,22 @@ commands =
     coveralls
 
 [testenv:ensure_non_running_provider]
-basepython = python3.6
 deps =
     PyYAML
 changedir = {toxinidir}/tests
 commands = {toxinidir}/tests/ensure_non_running_provider.py
+
+[testenv:molecule_lint]
+commands_pre =
+    molecule --version
+    ansible --version
+commands = molecule {posargs} lint
+
+[testenv:molecule_syntax]
+commands = molecule {posargs} syntax
+
+[testenv:molecule_test]
+commands = molecule {posargs} test
 
 [pytest]
 addopts = -rxs
@@ -153,6 +169,6 @@ max-line-length = 88
 python =
   2.6: py26
   2.7: py27,coveralls,flake8,pylint
-  3.6: py36,black,ensure_non_running_provider
+  3.6: py36,black,ensure_non_running_provider,molecule_lint,molecule_syntax,molecule_test
   3.7: py37
   3.8: py38


### PR DESCRIPTION
Configures Molecule to do basic checks (lint/syntax, run, idempotence, Ansible check mode functionality) of the role with default parameters (tests/tests_default.yml) using Travis CI and centos6/7 docker containers.

Because Travis was already used by network role, please check mainly .travis.yml, whether it makes sense to incorporate molecule into it in this way.