### PR TITLE
tests: Test setting the MTU of VLAN interfaces

### DIFF
--- a/tests/ensure_non_running_provider.py
+++ b/tests/ensure_non_running_provider.py
@@ -13,7 +13,13 @@ import yaml
 
 OTHER_PROVIDER_SUFFIX = "_other_provider.yml"
 
-IGNORE = ["tests_unit.yml", "tests_helpers-and-asserts.yml", "tests_states.yml"]
+IGNORE = [
+    "tests_helpers-and-asserts.yml",
+    "tests_states.yml",
+    "tests_unit.yml",
+    "tests_vlan_mtu_initscripts.yml",
+    "tests_vlan_mtu_nm.yml",
+]
 
 OTHER_PLAYBOOK = """
 # SPDX-License-Identifier: BSD-3-Clause

--- a/tests/playbooks/tests_vlan_mtu.yml
+++ b/tests/playbooks/tests_vlan_mtu.yml
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: BSD-3-Clause
+---
+- hosts: all
+  vars:
+    type: veth
+    interface: lsr101
+    vlan_interface: lsr101.90
+  tasks:
+    - include_tasks: tasks/show-interfaces.yml
+    - include_tasks: tasks/manage-test-interface.yml
+      vars:
+        state: present
+    - include_tasks: tasks/assert-device_present.yml
+    - name: "TEST: I can configure the MTU for a vlan interface without autoconnect."
+      import_role:
+        name: linux-system-roles.network
+      vars:
+        network_connections:
+          - name: "{{ interface }}"
+            type: ethernet
+            state: up
+            mtu: 1492
+            autoconnect: false
+            ip:
+              dhcp4: false
+              auto6: false
+
+          - name: "{{ vlan_interface }}"
+            parent: "{{ interface }}"
+            type: vlan
+            vlan_id: 90
+            mtu: 1280
+            state: up
+            autoconnect: false
+            ip:
+              dhcp4: false
+              auto6: false
+    - include_tasks: tasks/assert-device_present.yml
+      vars:
+        interface: "{{ vlan_interface }}"
+    - include_tasks: tasks/assert-profile_present.yml
+      vars:
+        profile: "{{ item }}"
+      loop:
+        -  "{{ interface }}"
+        -  "{{ vlan_interface }}"
+
+    - name: "CLEANUP: remove profiles"
+      import_role:
+        name: linux-system-roles.network
+      vars:
+        network_connections:
+          - name: "{{ interface }}"
+            persistent_state: absent
+            state: down
+          - name: "{{ vlan_interface }}"
+            persistent_state: absent
+            state: down
+      ignore_errors: true
+    - include_tasks: tasks/manage-test-interface.yml
+      vars:
+        state: absent

--- a/tests/tests_vlan_mtu_initscripts.yml
+++ b/tests/tests_vlan_mtu_initscripts.yml
@@ -1,0 +1,12 @@
+---
+# empty playbook to gather facts for import_playbook when clause
+- hosts: all
+  vars:
+    network_provider: initscripts
+
+# workaround for: https://github.com/ansible/ansible/issues/27973
+# There is no way in Ansible to abort a playbook hosts with specific OS
+# releases Therefore we include the playbook with the tests only if the hosts
+# would support it.
+# The test requires NetworkManager, therefore it cannot run on RHEL 6 or CentOS 6.
+- import_playbook: playbooks/tests_vlan_mtu.yml

--- a/tests/tests_vlan_mtu_nm.yml
+++ b/tests/tests_vlan_mtu_nm.yml
@@ -1,0 +1,13 @@
+---
+# empty playbook to gather facts for import_playbook when clause
+- hosts: all
+  vars:
+    network_provider: nm
+
+# workaround for: https://github.com/ansible/ansible/issues/27973
+# There is no way in Ansible to abort a playbook hosts with specific OS
+# releases Therefore we include the playbook with the tests only if the hosts
+# would support it.
+# The test requires NetworkManager, therefore it cannot run on RHEL 6 or CentOS 6.
+- import_playbook: playbooks/tests_vlan_mtu.yml
+  when: ansible_distribution_major_version != '6'


### PR DESCRIPTION
Test setting the MTU interfaces. This needs autoconnect:false for now,
possibly because of a bug in NetworkManager.

This tests that #101 works but because of #102 it cannot enable autoconnect (which is the default, therefore it is explicitly disabled here).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/linux-system-roles/network/110)
<!-- Reviewable:end -->
