### PR TITLE
tox: Work around Python 2.6 issues with tox 3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,8 @@ deps = black
 commands = black --check --diff --include "^[^.].*\.py$" .
 
 [testenv:py26]
+install_command = pip install {opts} {packages}
+list_dependencies_command = pip freeze
 basepython = python2.6
 passenv = {[base]passenv}
 setenv =


### PR DESCRIPTION
Fedora 30 uses tox 3 which does not work with Python 2.6 out of the box.
Setting the install and list_dependencies commands to run `pip` instead
of `python -m pip` seems to fix this for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/linux-system-roles/network/117)
<!-- Reviewable:end -->
