### PR TITLE
Allow more BONDING_OPTS

### DIFF
--- a/module_utils/network_lsr/argument_validator.py
+++ b/module_utils/network_lsr/argument_validator.py
@@ -789,12 +789,29 @@ class ArgValidator_DictBond(ArgValidatorDict):
         "balance-alb",
     ]
 
+    VALID_RESELECT = ["always", "better", "failure"]
+
     def __init__(self):
         ArgValidatorDict.__init__(
             self,
             name="bond",
             nested=[
                 ArgValidatorStr("mode", enum_values=ArgValidator_DictBond.VALID_MODES),
+                ArgValidatorNum(
+                    "use_carrier", val_min=0, val_max=1, default_value=None
+                ),
+                ArgValidatorNum(
+                    "updelay", val_min=0, numeric_type=int, default_value=None
+                ),
+                ArgValidatorNum(
+                    "downdelay", val_min=0, numeric_type=int, default_value=None
+                ),
+                ArgValidatorStr("primary", default_value=None),
+                ArgValidatorStr(
+                    "primary_reselect",
+                    enum_values=ArgValidator_DictBond.VALID_RESELECT,
+                    default_value=None,
+                ),
                 ArgValidatorNum(
                     "miimon", val_min=0, val_max=1000000, default_value=None
                 ),
@@ -803,7 +820,15 @@ class ArgValidator_DictBond(ArgValidatorDict):
         )
 
     def get_default_bond(self):
-        return {"mode": ArgValidator_DictBond.VALID_MODES[0], "miimon": None}
+        return {
+            "mode": ArgValidator_DictBond.VALID_MODES[0],
+            "miimon": None,
+            "use_carrier": None,
+            "updelay": None,
+            "downdelay": None,
+            "primary": None,
+            "primary_reselect": None,
+        }
 
 
 class ArgValidator_DictInfiniband(ArgValidatorDict):


### PR DESCRIPTION
At the moment the role supports configuring the BONDING_OPTS parameters `mode` and `miimon`, however a great variety of parameters might also be supported.

This PR adds support for `use_carrier`, `updelay`, `downdelay`, `primary_reselect` and `primary`. Appreciate that's still only a small subset so I understand if you'd rather reject and wait for someone to do a fuller job, but these are the ones I needed for my project so thought I'd share.

Probably the biggest gap is that `primary` refers to the name of another network_connection. I've left that direct (i.e., you specify the `interface_name`) but I guess you might want to match the behaviour you have for `master` which takes the Ansible profile name and converts. 