### PR TITLE
Travis: Add stable Python 3.8, remove 3.7-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - python: 3.5
     - python: 3.6
     - python: 3.7
-    - python: 3.7-dev
+    - python: 3.8
     - python: 3.8-dev
 
 services:


### PR DESCRIPTION
Python 3.8 was released and will be used in Fedora Rawhide/Fedora 32.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/linux-system-roles/network/137)
<!-- Reviewable:end -->
