### PR TITLE
Add support for xmit_hash_policy for bond interface

### DIFF
--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -346,6 +346,8 @@ class IfcfgUtil:
             opts = ["mode=%s" % (connection["bond"]["mode"])]
             if connection["bond"]["miimon"] is not None:
                 opts.append(" miimon=%s" % (connection["bond"]["miimon"]))
+            if connection["bond"]["xmit_hash_policy"] is not None:
+                opts.append(" xmit_hash_policy=%s" % (connection["bond"]["xmit_hash_policy"]))
             ifcfg["BONDING_OPTS"] = " ".join(opts)
         elif connection["type"] == "team":
             ifcfg["DEVICETYPE"] = "Team"
@@ -815,6 +817,8 @@ class NMUtil:
             s_bond.add_option("mode", connection["bond"]["mode"])
             if connection["bond"]["miimon"] is not None:
                 s_bond.add_option("miimon", str(connection["bond"]["miimon"]))
+            if connection["bond"]["xmit_hash_policy"] is not None:
+                s_bond.add_option("xmit_hash_policy", str(connection["bond"]["xmit_hash_policy"]))
         elif connection["type"] == "team":
             s_con.set_property(NM.SETTING_CONNECTION_TYPE, NM.SETTING_TEAM_SETTING_NAME)
         elif connection["type"] == "vlan":

--- a/module_utils/network_lsr/argument_validator.py
+++ b/module_utils/network_lsr/argument_validator.py
@@ -628,12 +628,15 @@ class ArgValidator_DictBond(ArgValidatorDict):
                 ArgValidatorNum(
                     "miimon", val_min=0, val_max=1000000, default_value=None
                 ),
+                ArgValidatorNum(
+                    "xmit_hash_policy", val_min=0, val_max=2, default_value=None
+                ),
             ],
             default_value=ArgValidator.MISSING,
         )
 
     def get_default_bond(self):
-        return {"mode": ArgValidator_DictBond.VALID_MODES[0], "miimon": None}
+        return {"mode": ArgValidator_DictBond.VALID_MODES[0], "miimon": None, "xmit_hash_policy": None}
 
 
 class ArgValidator_DictInfiniband(ArgValidatorDict):

--- a/tests/unit/test_network_connections.py
+++ b/tests/unit/test_network_connections.py
@@ -1225,7 +1225,7 @@ class TestValidator(unittest.TestCase):
                 {
                     "actions": ["present", "up"],
                     "autoconnect": True,
-                    "bond": {"mode": "balance-rr", "miimon": None},
+                    "bond": {"mode": "balance-rr", "miimon": None, "xmit_hash_policy": None},
                     "check_iface_exists": True,
                     "ethernet": ETHERNET_DEFAULTS,
                     "ethtool": ETHTOOL_DEFAULTS,
@@ -1270,7 +1270,7 @@ class TestValidator(unittest.TestCase):
                 {
                     "actions": ["present", "up"],
                     "autoconnect": True,
-                    "bond": {"mode": "active-backup", "miimon": None},
+                    "bond": {"mode": "active-backup", "miimon": None, "xmit_hash_policy": None},
                     "check_iface_exists": True,
                     "ethernet": ETHERNET_DEFAULTS,
                     "ethtool": ETHTOOL_DEFAULTS,


### PR DESCRIPTION
See: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/networking_guide/sec-using_channel_bonding