### PR TITLE
Onboard refactored tox & Travis CI setup and configuration vol. 1

### DIFF
--- a/.travis/config.sh
+++ b/.travis/config.sh
@@ -1,4 +1,11 @@
 # SPDX-License-Identifier: MIT
-export LSR_MOLECULE_DEPS='-rmolecule_requirements.txt'
+#
+# Use this file to specify custom configuration for a project. Generally, this
+# involves the modification of the content of LSR_* environment variables, see
+#
+#   * .travis/preinstall:
+#
+#       - LSR_EXTRA_PACKAGES
+#
 
-LSR_EXTRA_PACKAGES='python3-selinux'
+export LSR_MOLECULE_DEPS='-rmolecule_requirements.txt'

--- a/.travis/preinstall
+++ b/.travis/preinstall
@@ -1,18 +1,30 @@
 #!/bin/bash
 # SPDX-License-Identifier: MIT
 
-set -ex
+# Install package specified by user in LSR_EXTRA_PACKAGES. Executed by Travis
+# during before_install phase.
+#
+# LSR_EXTRA_PACKAGES, set by user in .travis/config.sh, is a space separated
+# list of packages to be installed on the Travis build environment (Ubuntu).
 
-SCRIPTDIR=$(dirname $0)
-CONFIG=${SCRIPTDIR}/config.sh
+set -e
 
-if [[ -f ${CONFIG} ]]; then
-  . ${CONFIG}
+SCRIPTDIR=$(readlink -f $(dirname $0))
+
+. ${SCRIPTDIR}/utils.sh
+
+# Add python3-selinux package (needed by Molecule on selinux enabled systems,
+# because Molecule is using `copy` and `file` Ansible modules to setup the
+# container).
+if lsr_venv_python_matches_system_python; then
+  LSR_EXTRA_PACKAGES='python3-selinux'
 fi
 
+. ${SCRIPTDIR}/config.sh
+
+# Install extra dependencies.
 if [[ "${LSR_EXTRA_PACKAGES}" ]]; then
+  set -x
   sudo apt-get update
-  for P in ${LSR_EXTRA_PACKAGES}; do
-    sudo apt-get install -y ${P} || :
-  done
+  sudo apt-get install -y ${LSR_EXTRA_PACKAGES}
 fi

--- a/.travis/utils.sh
+++ b/.travis/utils.sh
@@ -134,3 +134,12 @@ function lsr_compare_pythons() {
   lsr_compare_versions \
     $(lsr_get_python_version $1) $2 $(lsr_get_python_version $3)
 }
+
+##
+# lsr_venv_python_matches_system_python
+#
+# Exit with 0 if virtual environment Python version matches the system Python
+# version.
+function lsr_venv_python_matches_system_python() {
+  lsr_compare_pythons python -eq /usr/bin/python3
+}


### PR DESCRIPTION
This is a first batch of changes introduced by PR #133 (changes are introduced in batches to make reviews easier). List of changes introduced in this PR:
- document used/introduced environment variables in comments
- use absolute pathes to `config.sh` and `utils.sh`
- include `config.sh` unconditionally (`config.sh` is now a part of template, so it is created by autosynchronization script if it does not exist)
- if `python` is a system python, install `python3-selinux` (`python3-selinux` is installed by default; in case there is a reason to not install `python3-selinux`, it can be removed from `LSR_EXTRA_PACKAGES` by `config.sh`)
- install `LSR_EXTRA_PACKAGES` in one command (increase performance)