### PR TITLE
custom_requirements.txt: Add environment marker

### DIFF
--- a/custom_requirements.txt
+++ b/custom_requirements.txt
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: MIT
 
 # Write requirements for running your custom commands in tox here:
-PyYAML
+PyYAML; python_version == '2.7' or python_version >= '3.5'


### PR DESCRIPTION
Specify on which environments PyYAML should be installed to prevent
failing pip install.