### PR TITLE
Onboard refactored tox & Travis CI setup and configuration vol. 2

### DIFF
--- a/.travis/runpytest.sh
+++ b/.travis/runpytest.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+# A shell wrapper around pytest. As pytest is sensitive on a content of project
+# directory: if a project contains no unit tests, pytest fails. Similarly if
+# there is nothing to be analyzed with coverage, running pytest with --cov*
+# arguments may lead to problems. For this reasons, this shell wrapper skips
+# running pytest if there are no unit tests and filters out --cov*/--no-cov*
+# arguments if there is nothing to be analyzed with coverage.
+
+# First argument to the script is a path to environment python, the rest of
+# arguments are passed to pytest.
+
+set -e
+
+ME=$(basename $0)
+SCRIPTDIR=$(readlink -f $(dirname $0))
+TOPDIR=$(readlink -f ${SCRIPTDIR}/..)
+
+. ${SCRIPTDIR}/utils.sh
+
+if [[ ! -d ${TOPDIR}/tests/unit ]]; then
+  lsr_info "${ME}: No unit tests found. Skipping."
+  exit 0
+fi
+
+# Sanitize path in case if running within tox (see
+# https://github.com/tox-dev/tox/issues/1463):
+ENVPYTHON=$(readlink -f $1)
+shift
+
+PYTEST_OPTS=()
+PYTEST_OPTS_NOCOV=()
+USE_COV=no
+
+# Filter out coverage options if there is nothing to be analyzed with coverage.
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cov=*)
+      if [[ "${1:6}" && -d "${1:6}" ]]; then
+        USE_COV=yes
+        PYTEST_OPTS+=( "$1" )
+      fi
+      ;;
+    --cov*|--no-cov*)
+      PYTEST_OPTS+=( "$1" )
+      ;;
+    *)
+      PYTEST_OPTS+=( "$1" )
+      PYTEST_OPTS_NOCOV+=( "$1" )
+      ;;
+  esac
+  shift
+done
+
+if [[ "${USE_COV}" == "no" ]]; then
+  PYTEST_OPTS=( "${PYTEST_OPTS_NOCOV[@]}" )
+fi
+
+set -x
+${ENVPYTHON} -m pytest "${PYTEST_OPTS[@]}"

--- a/tox.ini
+++ b/tox.ini
@@ -23,10 +23,11 @@ setenv =
     PYTHONPATH = {toxinidir}/library:{toxinidir}/module_utils
     LC_ALL = C
 changedir = {toxinidir}/tests
-covtarget = {toxinidir}/library --cov {toxinidir}/module_utils
-pytesttarget = .
+covtargets = --cov={toxinidir}/library --cov={toxinidir}/module_utils
+pytesttarget = unit
 whitelist_externals =
     bash
+runpytest = {toxinidir}/.travis/runpytest.sh
 
 [testenv:py26]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:2.6}
@@ -39,13 +40,16 @@ passenv = {[base]passenv}
 setenv =
     {[base]setenv}
 changedir = {[base]changedir}
+whitelist_externals =
+    {[base]whitelist_externals}
 commands =
-    pytest --durations=5 \
-           --cov={[base]covtarget} \
-           --cov-report=html:htmlcov-py26 \
-           --cov-report=term \
-           {posargs} \
-           {[base]pytesttarget}
+    bash {[base]runpytest} {envpython} \
+         --durations=5 \
+         {[base]covtargets} \
+         --cov-report=html:htmlcov-py26 \
+         --cov-report=term \
+         {posargs} \
+         {[base]pytesttarget}
 
 [testenv:py27]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:2.7}
@@ -54,13 +58,16 @@ passenv = {[base]passenv}
 setenv =
     {[base]setenv}
 changedir = {[base]changedir}
+whitelist_externals =
+    {[base]whitelist_externals}
 commands =
-    pytest --durations=5 \
-           --cov={[base]covtarget} \
-           --cov-report=html:htmlcov-py27 \
-           --cov-report=term \
-           {posargs} \
-           {[base]pytesttarget}
+    bash {[base]runpytest} {envpython} \
+         --durations=5 \
+         {[base]covtargets} \
+         --cov-report=html:htmlcov-py27 \
+         --cov-report=term \
+         {posargs} \
+         {[base]pytesttarget}
 
 [testenv:py36]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:3.6}
@@ -69,13 +76,16 @@ passenv = {[base]passenv}
 setenv =
     {[base]setenv}
 changedir = {[base]changedir}
+whitelist_externals =
+    {[base]whitelist_externals}
 commands =
-    pytest --durations=5 \
-           --cov={[base]covtarget} \
-           --cov-report=html:htmlcov-py36 \
-           --cov-report=term \
-           {posargs} \
-           {[base]pytesttarget}
+    bash {[base]runpytest} {envpython} \
+         --durations=5 \
+         {[base]covtargets} \
+         --cov-report=html:htmlcov-py36 \
+         --cov-report=term \
+         {posargs} \
+         {[base]pytesttarget}
 
 [testenv:py37]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:3.7}
@@ -84,13 +94,16 @@ passenv = {[base]passenv}
 setenv =
     {[base]setenv}
 changedir = {[base]changedir}
+whitelist_externals =
+    {[base]whitelist_externals}
 commands =
-    pytest --durations=5 \
-           --cov={[base]covtarget} \
-           --cov-report=html:htmlcov-py37 \
-           --cov-report=term \
-           {posargs} \
-           {[base]pytesttarget}
+    bash {[base]runpytest} {envpython} \
+         --durations=5 \
+         {[base]covtargets} \
+         --cov-report=html:htmlcov-py37 \
+         --cov-report=term \
+         {posargs} \
+         {[base]pytesttarget}
 
 [testenv:py38]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:3.8}
@@ -99,13 +112,16 @@ passenv = {[base]passenv}
 setenv =
     {[base]setenv}
 changedir = {[base]changedir}
+whitelist_externals =
+    {[base]whitelist_externals}
 commands =
-    pytest --durations=5 \
-           --cov={[base]covtarget} \
-           --cov-report=html:htmlcov-py38 \
-           --cov-report=term \
-           {posargs} \
-           {[base]pytesttarget}
+    bash {[base]runpytest} {envpython} \
+         --durations=5 \
+         {[base]covtargets} \
+         --cov-report=html:htmlcov-py38 \
+         --cov-report=term \
+         {posargs} \
+         {[base]pytesttarget}
 
 [testenv:black]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:3.6}


### PR DESCRIPTION
This is a second batch of changes introduced by PR #133 (changes are introduced in batches to make reviews easier). List of changes introduced in this PR:
- shell wrapper around `pytest` (decides when to run `pytest` and with what arguments - some system roles do not contain Python code which confuses `pytest`)