### PR TITLE
Onboard refactored tox & Travis CI setup and configuration vol. 3

### DIFF
--- a/.travis/config.sh
+++ b/.travis/config.sh
@@ -7,5 +7,14 @@
 #
 #       - LSR_EXTRA_PACKAGES
 #
+# Environment variables that not start with LSR_* but have influence on CI
+# process:
+#
+#   * .travis/runblack.sh:
+#
+#       - RUN_BLACK_INCLUDE
+#       - RUN_BLACK_EXCLUDE
+#       - RUN_BLACK_DISABLED
+#
 
 export LSR_MOLECULE_DEPS='-rmolecule_requirements.txt'

--- a/.travis/runblack.sh
+++ b/.travis/runblack.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+# A shell wrapper around black (Python formatter). The purpose of this wrapper
+# is to get a user the opportunity to control black from config.sh via setting
+# environment variables.
+
+# The first script argument is a path to Python interpreter, the rest of
+# arguments are passed to black.
+
+# Environment variables:
+#
+#   RUN_BLACK_INCLUDE
+#     a regular expression specifying files to be included; can be overridden
+#     from command line by --include;
+#
+#   RUN_BLACK_EXCLUDE
+#     a regular expression specifying files to be excluded; can be overridden
+#     from command line by --exclude;
+#
+#   RUN_BLACK_DISABLED
+#     if set to an arbitrary non-empty value, black will be not executed
+
+set -e
+
+ME=$(basename $0)
+SCRIPTDIR=$(readlink -f $(dirname $0))
+
+. ${SCRIPTDIR}/utils.sh
+. ${SCRIPTDIR}/config.sh
+
+if [[ "${RUN_BLACK_DISABLED}" ]]; then
+  lsr_info "${ME}: black is disabled. Skipping."
+  exit 0
+fi
+
+# Sanitize path in case if running within tox (see
+# https://github.com/tox-dev/tox/issues/1463):
+ENVPYTHON=$(readlink -f $1)
+shift
+
+DEFAULT_INCLUDE='^[^.].*\.py$'
+DEFAULT_EXCLUDE='/(\.[^.].*|tests/roles)/'
+
+INCLUDE_ARG=""
+EXCLUDE_ARG=""
+OTHER_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --include)
+      shift
+      INCLUDE_ARG="$1"
+      ;;
+    --exclude)
+      shift
+      EXCLUDE_ARG="$1"
+      ;;
+    *)
+      OTHER_ARGS+=( "$1" )
+      ;;
+  esac
+  shift
+done
+
+set -x
+${ENVPYTHON} -m black \
+  --include "${INCLUDE_ARG:-${RUN_BLACK_INCLUDE:-${DEFAULT_INCLUDE}}}" \
+  --exclude "${EXCLUDE_ARG:-${RUN_BLACK_EXCLUDE:-${DEFAULT_EXCLUDE}}}" \
+  "${OTHER_ARGS[@]}"

--- a/tox.ini
+++ b/tox.ini
@@ -126,10 +126,13 @@ commands =
 [testenv:black]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:3.6}
 basepython = python3.6
+passenv = RUN_BLACK_*
 deps =
     black
+whitelist_externals =
+    {[base]whitelist_externals}
 commands =
-    black --check --diff --include "^[^.].*\.py$" --exclude "/(\.[^.].*|tests/roles)/" .
+    bash {toxinidir}/.travis/runblack.sh {envpython} --check --diff .
 
 [testenv:pylint]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:2.7}


### PR DESCRIPTION
This is a third batch of changes introduced by PR #133 (changes are introduced in batches to make reviews easier). List of changes introduced in this PR:
- wrap `black` - some system roles want not to run `black` on their code, so allow to control `black` via `config.sh`
