### PR TITLE
Onboard refactored tox & Travis CI setup and configuration vol. 4

### DIFF
--- a/.travis/config.sh
+++ b/.travis/config.sh
@@ -10,6 +10,12 @@
 # Environment variables that not start with LSR_* but have influence on CI
 # process:
 #
+#   * .travis/runpylint.sh:
+#
+#       - RUN_PYLINT_INCLUDE
+#       - RUN_PYLINT_EXCLUDE
+#       - RUN_PYLINT_DISABLED
+#
 #   * .travis/runblack.sh:
 #
 #       - RUN_BLACK_INCLUDE

--- a/.travis/custom_pylint.py
+++ b/.travis/custom_pylint.py
@@ -1,7 +1,7 @@
 #                                                         -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 #
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2020 Red Hat, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,7 @@
 """
 Probe directory tree for python files and pass them to pylint.
 
-Usage: python run_pylint.py ARGUMENTS
+Usage: python custom_pylint.py ARGUMENTS
 
 Run pylint with ARGUMENTS followed by the list of python files contained in the
 working directory and its subdirectories.  As a python file is recognized a

--- a/.travis/runpylint.sh
+++ b/.travis/runpylint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+# A shell wrapper around custom_pylint.py. The purpose of this wrapper is to
+# set environment variables defined in config.sh before custom_pylint.py
+# invocation, so user can control what should be pylinted via config.sh.
+
+# Note: Prior this change, RUN_PYLINT_* environment variables set in config.sh
+#       take effect only when running inside Travis (because of runtox script
+#       which set them by including config.sh). Now, they take effect also when
+#       running tox locally.
+
+# First argument to the script is a path to environment python, the rest of
+# arguments are passed to custom_pylint.py.
+
+set -e
+
+ME=$(basename $0)
+SCRIPTDIR=$(readlink -f $(dirname $0))
+
+. ${SCRIPTDIR}/config.sh
+
+# Sanitize path in case if running within tox (see
+# https://github.com/tox-dev/tox/issues/1463):
+ENVPYTHON=$(readlink -f $1)
+shift
+
+set -x
+${ENVPYTHON} ${SCRIPTDIR}/custom_pylint.py "$@"

--- a/tox.ini
+++ b/tox.ini
@@ -145,8 +145,10 @@ deps =
     pylint>=1.8.4
     ansible
     -rpylint_extra_requirements.txt
+whitelist_externals =
+    {[base]whitelist_externals}
 commands =
-    {envpython} ./run_pylint.py --errors-only {posargs}
+    bash {toxinidir}/.travis/runpylint.sh {envpython} --errors-only {posargs}
 
 [testenv:flake8]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:2.7}


### PR DESCRIPTION
This is a 4th batch of changes introduced by PR #133 (changes are introduced in batches to make reviews easier). List of changes introduced in this PR:
- rename `run_pylint.py` to `custom_pylint.py` (this is what the script really is - a customized `pylint`) and move it to `.travis/` directory where all auxiliary scripts should be placed
- call `custom_pylint.py` via shell wrapper so environment variables set by `config.sh` takes effect also when `tox` runs locally
