### PR TITLE
Onboard refactored tox & Travis CI setup and configuration vol. 5

### DIFF
--- a/.travis/config.sh
+++ b/.travis/config.sh
@@ -22,5 +22,9 @@
 #       - RUN_BLACK_EXCLUDE
 #       - RUN_BLACK_DISABLED
 #
+#   * .travis/runflake8.sh:
+#
+#       - RUN_FLAKE8_DISABLED
+#
 
 export LSR_MOLECULE_DEPS='-rmolecule_requirements.txt'

--- a/.travis/runflake8.sh
+++ b/.travis/runflake8.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+# A shell wrapper around flake8. The purpose of this wrapper is to get to user
+# an opportunity to disable running flake8 via config.sh.
+
+# The first script argument is a path to Python interpreter, the rest of
+# arguments are passed to flake8.
+
+# Environment variables:
+#
+#   RUN_FLAKE8_DISABLED
+#     if set to an arbitrary non-empty value, flake8 will be not executed
+
+set -e
+
+ME=$(basename $0)
+SCRIPTDIR=$(readlink -f $(dirname $0))
+
+. ${SCRIPTDIR}/utils.sh
+. ${SCRIPTDIR}/config.sh
+
+if [[ "${RUN_FLAKE8_DISABLED}" ]]; then
+  lsr_info "${ME}: flake8 is disabled. Skipping."
+  exit 0
+fi
+
+# Sanitize path in case if running within tox (see
+# https://github.com/tox-dev/tox/issues/1463):
+ENVPYTHON=$(readlink -f $1)
+shift
+
+set -x
+${ENVPYTHON} -m flake8 "$@"

--- a/tox.ini
+++ b/tox.ini
@@ -153,11 +153,13 @@ commands =
 [testenv:flake8]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:2.7}
 basepython = python2.7
+passenv = RUN_FLAKE8_*
 deps =
     flake8>=3.5
-whitelist_externals = flake8
+whitelist_externals =
+    {[base]whitelist_externals}
 commands =
-    flake8 --statistics {posargs} .
+    bash {toxinidir}/.travis/runflake8.sh {envpython} --statistics {posargs} .
 
 [testenv:coveralls]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:coveralls}


### PR DESCRIPTION
This is a 5th batch of changes introduced by PR #133 (changes are introduced in batches to make reviews easier). List of changes introduced in this PR:
- wrap `flake8` into a shell script so users can dissable it via `config.sh`
