### PR TITLE
Onboard refactored tox & Travis CI setup and configuration vol. 6

### DIFF
--- a/.travis/config.sh
+++ b/.travis/config.sh
@@ -26,5 +26,3 @@
 #
 #       - RUN_FLAKE8_DISABLED
 #
-
-export LSR_MOLECULE_DEPS='-rmolecule_requirements.txt'

--- a/molecule_extra_requirements.txt
+++ b/molecule_extra_requirements.txt
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: MIT
+
+# Write extra requirements for running molecule here:
+jmespath

--- a/molecule_requirements.txt
+++ b/molecule_requirements.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: MIT
-jmespath
-selinux

--- a/tox.ini
+++ b/tox.ini
@@ -172,21 +172,12 @@ commands =
     bash -c 'cd ..; bash .travis/fix-coverage.sh; cd -'
     coveralls
 
-# LSR_MOLECULE_DEPS may contain aditional Molecule dependencies. For example,
-# in `network` system role, LSR_MOLECULE_DEPS can be set as
-#
-#   LSR_MOLECULE_DEPS='-rmolecule_requirements.txt'
-#
-# where `molecule_requirements.txt` contains two lines:
-#
-#   jmespath
-#   selinux
-#
 [molecule_common]
 deps =
     docker
     molecule
-    {env:LSR_MOLECULE_DEPS:}
+    selinux
+    -rmolecule_extra_requirements.txt
 
 [testenv:molecule_lint]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:molecule}


### PR DESCRIPTION
This is a 6th batch of changes introduced by PR #133 (changes are introduced in batches to make reviews easier). List of changes introduced in this PR:
- remove `LSR_MOLECULE_DEPS` environment variable (instead, use `molecule_extra_requirements.txt` permanently as a place where to add additional molecule dependencies)
- permanently add `selinux` to molecule dependencies (molecule needs it on selinux enabled systems to setup containers)
