### PR TITLE
Onboard refactored tox & Travis CI setup and configuration vol. 7

### DIFF
--- a/.travis/runsyspycmd.sh
+++ b/.travis/runsyspycmd.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+# Execute command in environment python only if environment python has access
+# to system python libraries, especially C bindings. The script is run with
+# these arguments:
+#
+#   $1     - path to environment python
+#   $2     - path to system python
+#   $3     - command runnable in Python (should be present in $PATH)
+#   ${@:4} - arguments passed to $3
+
+set -e
+
+ME=$(basename $0)
+SCRIPTDIR=$(readlink -f $(dirname $0))
+TOPDIR=$(readlink -f ${SCRIPTDIR}/..)
+
+. ${SCRIPTDIR}/utils.sh
+. ${SCRIPTDIR}/config.sh
+
+# Sanitize arguments (see https://github.com/tox-dev/tox/issues/1463):
+ENVPYTHON=$(readlink -f $1)
+SYSPYTHON=$(readlink -f $2)
+shift 2
+
+if ! lsr_venv_python_matches_system_python ${ENVPYTHON} ${SYSPYTHON}; then
+  lsr_info "${ME}: ${1:-<missing command>}:" \
+    "Environment Python has no access to system Python libraries. Skipping."
+  exit 0
+fi
+
+COMMAND=$(command -v $1)
+shift
+
+set -x
+${ENVPYTHON} ${COMMAND} "$@"

--- a/.travis/utils.sh
+++ b/.travis/utils.sh
@@ -136,10 +136,14 @@ function lsr_compare_pythons() {
 }
 
 ##
-# lsr_venv_python_matches_system_python
+# lsr_venv_python_matches_system_python [$1] [$2]
+#
+#   $1 - command or full path to venv Python interpreter (default: python)
+#   $2 - command or full path to the system Python interpreter
+#        (default: /usr/bin/python3)
 #
 # Exit with 0 if virtual environment Python version matches the system Python
 # version.
 function lsr_venv_python_matches_system_python() {
-  lsr_compare_pythons python -eq /usr/bin/python3
+  lsr_compare_pythons ${1:-python} -eq ${2:-/usr/bin/python3}
 }

--- a/tox.ini
+++ b/tox.ini
@@ -178,38 +178,58 @@ deps =
     molecule
     selinux
     -rmolecule_extra_requirements.txt
+runsyspycmd = {toxinidir}/.travis/runsyspycmd.sh
+
+[testenv:molecule_version]
+envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:molecule}
+deps =
+    {[molecule_common]deps}
+whitelist_externals =
+    {[base]whitelist_externals}
+commands =
+    bash {[molecule_common]runsyspycmd} {envpython} {[base]system_python} \
+         molecule --version
+    bash {[molecule_common]runsyspycmd} {envpython} {[base]system_python} \
+         ansible --version
 
 [testenv:molecule_lint]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:molecule}
 deps =
     {[molecule_common]deps}
-commands_pre =
-    molecule --version
-    ansible --version
+whitelist_externals =
+    {[base]whitelist_externals}
 commands =
-    molecule lint -s {env:LSR_MSCENARIO:default} {posargs}
+    bash {[molecule_common]runsyspycmd} {envpython} {[base]system_python} \
+         molecule lint -s {env:LSR_MSCENARIO:default} {posargs}
 
 [testenv:molecule_syntax]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:molecule}
 deps =
     {[molecule_common]deps}
+whitelist_externals =
+    {[base]whitelist_externals}
 commands =
-    molecule syntax -s {env:LSR_MSCENARIO:default} {posargs}
+    bash {[molecule_common]runsyspycmd} {envpython} {[base]system_python} \
+         molecule syntax -s {env:LSR_MSCENARIO:default} {posargs}
 
 [testenv:molecule_test]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:molecule}
 deps =
     {[molecule_common]deps}
+whitelist_externals =
+    {[base]whitelist_externals}
 commands =
-    molecule test -s {env:LSR_MSCENARIO:default} {posargs}
+    bash {[molecule_common]runsyspycmd} {envpython} {[base]system_python} \
+         molecule test -s {env:LSR_MSCENARIO:default} {posargs}
 
 [testenv:molecule]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:molecule}
 deps =
     {[molecule_common]deps}
-commands_pre =
-    {[testenv:molecule_lint]commands_pre}
+whitelist_externals =
+    {[base]whitelist_externals}
 commands =
+    {[testenv:molecule_version]commands}
     {[testenv:molecule_lint]commands}
     {[testenv:molecule_syntax]commands}
     {[testenv:molecule_test]commands}


### PR DESCRIPTION
This is a 7th batch of changes introduced by PR #133 (changes are introduced in batches to make reviews easier). List of changes introduced in this PR:
- `runsyspycmd.sh` script - runs a given command only if venv Python matches the system Python (this prevents failing when some command depends on binary libraries)
- put `molecule --version` and `ansible --version` to a standalone testenv (`[testenv:molecule_version]`) so a user can display molecule and ansible version by typing `tox -e molecule_version` without running `molecule lint`
