### PR TITLE
Onboard refactored tox & Travis CI setup and configuration vol. 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 ---
 dist: xenial
 language: python
+env:
+  global:
+    - LSR_ANSIBLES='ansible==2.6.* ansible==2.7.* ansible==2.8.*'
+    - LSR_MSCENARIOS='default'
 matrix:
   include:
     - python: 2.6

--- a/.travis/config.sh
+++ b/.travis/config.sh
@@ -7,6 +7,11 @@
 #
 #       - LSR_EXTRA_PACKAGES
 #
+#   * .travis/runtox:
+#
+#       - LSR_ANSIBLES
+#       - LSR_MSCENARIOS
+#
 # Environment variables that not start with LSR_* but have influence on CI
 # process:
 #

--- a/.travis/custom.sh
+++ b/.travis/custom.sh
@@ -13,7 +13,6 @@ ME=$(basename $0)
 SCRIPTDIR=$(readlink -f $(dirname $0))
 TOPDIR=$(readlink -f ${SCRIPTDIR}/..)
 
-# Include library and config:
 . ${SCRIPTDIR}/utils.sh
 . ${SCRIPTDIR}/config.sh
 

--- a/.travis/runtox
+++ b/.travis/runtox
@@ -1,16 +1,45 @@
 #!/bin/bash
 # SPDX-License-Identifier: MIT
 
-set -ex
+# Run tox. Additionally, if LSR_MSCENARIOS is defined, run `tox -e molecule`
+# for every scenario from LSR_MSCENARIOS and for every Ansible version from
+# LSR_ANSIBLES.
+#
+# LSR_MSCENARIOS is a space separated list of molecule scenarios.
+# LSR_ANSIBLES is a space separated list of Ansible package names with versions
+# in pip format, i.e 'ansible ansible==2.6 ansible==2.7 ansible=2.8'.
+#
+# LSR_MSCENARIOS and LSR_ANSIBLES can be set in .travis/config.sh or as
+# environment variables.
 
-SCRIPTDIR=$(dirname $0)
-CONFIG=${SCRIPTDIR}/config.sh
+ME=$(basename $0)
+SCRIPTDIR=$(readlink -f $(dirname $0))
+BANNERSIZE=90
 
-if [[ -f ${CONFIG} ]]; then
-  . ${CONFIG}
+. ${SCRIPTDIR}/utils.sh
+. ${SCRIPTDIR}/config.sh
+
+lsr_banner "tox" ${BANNERSIZE}
+(set -x; tox); error_code=$?
+
+# Exit prematurely if the environment is not suitable for running
+# Molecule tests.
+if ! lsr_venv_python_matches_system_python; then
+  exit $error_code
 fi
 
-tox "$@"
-for X in ${LSR_MSCENARIOS}; do
-  LSR_MSCENARIO=${X} tox -e molecule
+for ansible_dependency in ${LSR_ANSIBLES}; do
+  for molecule_scenario in ${LSR_MSCENARIOS}; do
+    lsr_banner \
+      "[${ansible_dependency}] tox -e molecule -- -s ${molecule_scenario}" \
+      ${BANNERSIZE}
+    (
+      set -x
+      LSR_ANSIBLE_DEP="${ansible_dependency}" \
+      LSR_MSCENARIO=${molecule_scenario} \
+      tox -e molecule
+    ) || error_code=$?
+  done
 done
+
+exit $error_code

--- a/tox.ini
+++ b/tox.ini
@@ -174,6 +174,7 @@ commands =
 
 [molecule_common]
 deps =
+    {env:LSR_ANSIBLE_DEP:ansible}
     docker
     molecule
     selinux
@@ -263,7 +264,7 @@ max-line-length = 88
 python =
   2.6: py26,custom
   2.7: py27,flake8,pylint,custom
-  3.5: coveralls,molecule,custom
+  3.5: coveralls,custom
   3.6: py36,black,custom
   3.7: py37,custom
   3.8: py38,custom


### PR DESCRIPTION
This is an 8th batch of changes introduced by PR #133 (changes are introduced in batches to make reviews easier). List of changes introduced in this PR:
- allow to run Molecule tests against more versions of Ansible
- allow to run custom commands also for Python 3.8-dev
- remove unecessary comment