### PR TITLE
Tox: Pin molecule to version 2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -176,7 +176,7 @@ commands =
 deps =
     {env:LSR_ANSIBLE_DEP:ansible}
     docker
-    molecule
+    molecule<3
     selinux
     -rmolecule_extra_requirements.txt
 runsyspycmd = {toxinidir}/.travis/runsyspycmd.sh


### PR DESCRIPTION
Molecule version 3 and later needs a different configuration file for
linters. This breaks the CI. Pin molecule to version 2 for now to
fix the CI until we have a proper fix.