### PR TITLE
Travis: Disable Python 3.8-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
     - python: 3.6
     - python: 3.7
     - python: 3.8
-    - python: 3.8-dev
 
 services:
   - docker


### PR DESCRIPTION
Python 3.8-dev seems to be broken on Travis, disable it for now.