### PR TITLE
Updating tests_bridge and tests_ethernet to be consistent with newer tests

### DIFF
--- a/tests/tests_bridge.yml
+++ b/tests/tests_bridge.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- name: Test configuring bridges
-  hosts: all
+- hosts: all
+  name: Test configuring bridges
   vars:
     interface: LSR-TST-br31
 
@@ -12,8 +12,8 @@
     - include_tasks: tasks/show-interfaces.yml
     - include_tasks: tasks/assert-device_absent.yml
 
-- name: Add test bridge
-  hosts: all
+- hosts: all
+  name: Add test bridge
   vars:
     network_connections:
       - name: "{{ interface }}"
@@ -48,8 +48,4 @@
   vars:
     profile: "{{ interface }}"
     task: tasks/assert-profile_absent.yml
-
 # FIXME: Devices might still be left when profile is absent
-#- import_playbook: run-tasks.yml
-#  vars:
-#    task: tasks/assert-device_absent.yml

--- a/tests/tests_ethernet.yml
+++ b/tests/tests_ethernet.yml
@@ -52,9 +52,10 @@
 - import_playbook: remove-profile.yml
   vars:
     profile: "{{ interface }}"
+
 # FIXME: assert profile away
-- name: Remove interfaces
-  hosts: all
+- hosts: all
+  name: Remove interfaces
   tasks:
     - include_tasks: tasks/manage-test-interface.yml
       vars:


### PR DESCRIPTION
I've updated these tests so they are now consistent with the new ones see [tests_ethool_feaures_nm](https://github.com/linux-system-roles/network/blob/master/tests/tests_ethtool_features_nm.yml)
Please do let me know if anything else needs to be done ,
Thanks