### PR TITLE
molecule/tox: Support yamllint without molecule

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MIT
 ---
+ignore: |
+  /.tox/
 extends: default
 rules:
   braces:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,7 +7,7 @@ driver:
 lint:
   name: yamllint
   options:
-    config-file: molecule/default/yamllint.yml
+    config-file: .yamllint.yml
 platforms:
   - name: centos-6
     image: docker.io/linuxsystemroles/centos-6

--- a/tests/ensure_non_running_provider.py
+++ b/tests/ensure_non_running_provider.py
@@ -59,7 +59,10 @@ def generate_nominal_other_playbook(tests_playbook):
     nominal_other_testfile_data = OTHER_PLAYBOOK.format(tests_playbook=tests_playbook)
     nominal = yaml.safe_load(nominal_other_testfile_data)
     nominal[0]["vars"]["network_provider_current"] = get_current_provider_code()
-    return yaml.dump(nominal, default_flow_style=False, explicit_start=True, width=80)
+    yaml_dump = yaml.dump(
+        nominal, default_flow_style=False, explicit_start=True, width=80
+    )
+    return "# yamllint disable\n" + yaml_dump
 
 
 def main():

--- a/tests/get-coverage.yml
+++ b/tests/get-coverage.yml
@@ -16,11 +16,15 @@
     # be its own task
     - name: set more facts
       set_fact:
-        coverage_file: ansible-coverage-{{ coverage_module }}-{{ test_playbook|replace('.yml', '') }}
+        coverage_file:
+          # yamllint disable-line rule:line-length
+          ansible-coverage-{{ coverage_module }}-{{ test_playbook|replace('.yml', '') }}
 
     - name: debug info
       debug:
-        msg: Getting coverage for '{{ coverage_module }}' with '{{ test_playbook }}'
+        msg:
+          # yamllint disable-line rule:line-length
+          Getting coverage for '{{ coverage_module }}' with '{{ test_playbook }}'
 
     # combine data in case old data is left there
     - command: "{{ coverage }} combine"
@@ -48,7 +52,8 @@
 
 - import_playbook: "{{ test_playbook }}"
   vars:
-    ansible_python_interpreter: "{{ coverage }} run -p --include *ansible_module_{{ coverage_module }}.py"
+    ansible_python_interpreter:
+      "{{ coverage }} run -p --include *ansible_module_{{ coverage_module }}.py"
 
 - name: Gather coverage data
   hosts: all

--- a/tests/playbooks/tests_ethtool_features.yml
+++ b/tests/playbooks/tests_ethtool_features.yml
@@ -18,7 +18,8 @@
         name: ethtool
         state: present
     - block:
-        - name: "TEST: I can create a profile without changing the ethtool features."
+        - name: >-
+            TEST: I can create a profile without changing the ethtool features.
           debug:
             msg: "##################################################"
         - name: Get current device features
@@ -41,7 +42,8 @@
           assert:
             that:
               - original_ethtool_features.stdout == ethtool_features.stdout
-        - name: "TEST: I can disable gro and tx-tcp-segmentation and enable gso."
+        - name: >-
+            TEST: I can disable gro and tx-tcp-segmentation and enable gso.
           debug:
             msg: "##################################################"
         - import_role:
@@ -68,9 +70,15 @@
         - name: Assert device features
           assert:
             that:
-              - "'generic-receive-offload: off' in ethtool_features.stdout_lines"
-              - "'generic-segmentation-offload: on' in ethtool_features.stdout_lines"
-              - "'tx-tcp-segmentation: off' in ethtool_features.stdout_lines | map('trim')"
+              - >-
+                  'generic-receive-offload: off' in
+                  ethtool_features.stdout_lines
+              - >-
+                  'generic-segmentation-offload: on' in
+                  ethtool_features.stdout_lines
+              - >-
+                  'tx-tcp-segmentation: off' in
+                  ethtool_features.stdout_lines | map('trim')
         - name: "TEST: I can reset features to their original value."
           debug:
             msg: "##################################################"

--- a/tests/playbooks/tests_vlan_mtu.yml
+++ b/tests/playbooks/tests_vlan_mtu.yml
@@ -11,7 +11,8 @@
       vars:
         state: present
     - include_tasks: tasks/assert-device_present.yml
-    - name: "TEST: I can configure the MTU for a vlan interface without autoconnect."
+    - name: >-
+        TEST: I can configure the MTU for a vlan interface without autoconnect.
       debug:
         msg: "##################################################"
     - import_role:
@@ -44,8 +45,8 @@
       vars:
         profile: "{{ item }}"
       loop:
-        -  "{{ interface }}"
-        -  "{{ vlan_interface }}"
+        - "{{ interface }}"
+        - "{{ vlan_interface }}"
 
     - name: "TEARDOWN: remove profiles."
       debug:

--- a/tests/tests_bridge.yml
+++ b/tests/tests_bridge.yml
@@ -50,6 +50,6 @@
     task: tasks/assert-profile_absent.yml
 
 # FIXME: Devices might still be left when profile is absent
-#- import_playbook: run-tasks.yml
-#  vars:
-#    task: tasks/assert-device_absent.yml
+# - import_playbook: run-tasks.yml
+#   vars:
+#     task: tasks/assert-device_absent.yml

--- a/tests/tests_bridge_other_provider.yml
+++ b/tests/tests_bridge_other_provider.yml
@@ -1,3 +1,4 @@
+# yamllint disable
 ---
 - hosts: all
   name: Run playbook 'tests_bridge.yml' with non-default provider

--- a/tests/tests_default_initscripts.yml
+++ b/tests/tests_default_initscripts.yml
@@ -5,5 +5,5 @@
     - name: Set network provider to 'initscripts'
       set_fact:
         network_provider: initscripts
-        
+
 - import_playbook: tests_default.yml

--- a/tests/tests_default_nm.yml
+++ b/tests/tests_default_nm.yml
@@ -6,7 +6,8 @@
       set_fact:
         network_provider: nm
 
-# The test should run with NetworkManager, therefore it cannot run on RHEL 6 or CentOS 6.
+# The test should run with NetworkManager, therefore it cannot run on
+# RHEL/CentOS 6
 - import_playbook: tests_default.yml
   when:
     - ansible_distribution_major_version != '6'

--- a/tests/tests_ethernet_other_provider.yml
+++ b/tests/tests_ethernet_other_provider.yml
@@ -1,3 +1,4 @@
+# yamllint disable
 ---
 - hosts: all
   name: Run playbook 'tests_ethernet.yml' with non-default provider

--- a/tests/tests_ethtool_features_nm.yml
+++ b/tests/tests_ethtool_features_nm.yml
@@ -20,7 +20,8 @@
 # There is no way in Ansible to abort a playbook hosts with specific OS
 # releases Therefore we include the playbook with the tests only if the hosts
 # would support it.
-# The test should run with NetworkManager, therefore it cannot run on RHEL 6 or CentOS 6.
+# The test should run with NetworkManager, therefore it cannot run on
+# RHEL/CentOS 6
 - import_playbook: playbooks/tests_ethtool_features.yml
   when:
     - ansible_distribution_major_version != '6'

--- a/tests/tests_helpers-and-asserts.yml
+++ b/tests/tests_helpers-and-asserts.yml
@@ -15,7 +15,8 @@
         type: dummy
         interface: dummy1298
 
-# FIXME: when: does not seem to work with include_tasks, therefore this cannot be safely tested for now
+# FIXME: when: does not seem to work with include_tasks, therefore this cannot
+# be safely tested for now
 #    - name: test tap interfaces
 #      include_tasks: tasks/create-and-remove-interface.yml
 #      vars:
@@ -23,5 +24,5 @@
 #        - interface: tap1298
 #      when: ansible_distribution_major_version > 6
 #      # ip tuntap does not exist on RHEL6
-#      # FIXME: Maybe use some other tool to manage devices, openvpn can do this,
-#      # but it is in EPEL
+#      # FIXME: Maybe use some other tool to manage devices, openvpn can do
+#      # this, but it is in EPEL

--- a/tests/tests_states.yml
+++ b/tests/tests_states.yml
@@ -6,6 +6,6 @@
 # There is no way in Ansible to abort a playbook hosts with specific OS
 # releases Therefore we include the playbook with the tests only if the hosts
 # would support it.
-# The test requires NetworkManager, therefore it cannot run on RHEL 6 or CentOS 6.
+# The test requires NetworkManager, therefore it cannot run on RHEL/CentOS 6
 - import_playbook: playbooks/tests_states.yml
   when: ansible_distribution_major_version != '6'

--- a/tests/tests_unit.yml
+++ b/tests/tests_unit.yml
@@ -4,6 +4,7 @@
   name: Setup for test running
   tasks:
     - name: Install EPEL on enterprise Linux for python2-mock
+      # yamllint disable-line rule:line-length
       command: yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
       args:
         warn: false
@@ -34,9 +35,9 @@
         dest: /tmp/test-unit-1/
         local_follow: false
       loop:
-      - ../library/network_connections.py
-      - unit/test_network_connections.py
-      - ../module_utils/network_lsr
+        - ../library/network_connections.py
+        - unit/test_network_connections.py
+        - ../module_utils/network_lsr
 
     - name: Create helpers directory
       file:
@@ -86,4 +87,5 @@
     - name: Ensure that at least one python unit test ran
       fail:
         msg: Tests did not run with python2 or python3
-      when: not (python2_available is succeeded or python3_available is succeeded)
+      when: not python2_available is succeeded and
+        not python3_available is succeeded

--- a/tests/tests_vlan_mtu_nm.yml
+++ b/tests/tests_vlan_mtu_nm.yml
@@ -10,6 +10,6 @@
 # There is no way in Ansible to abort a playbook hosts with specific OS
 # releases Therefore we include the playbook with the tests only if the hosts
 # would support it.
-# The test requires NetworkManager, therefore it cannot run on RHEL 6 or CentOS 6.
+# The test requires NetworkManager, therefore it cannot run on RHEL/CentOS 6
 - import_playbook: playbooks/tests_vlan_mtu.yml
   when: ansible_distribution_major_version != '6'

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 [tox]
 envlist =
-    black, pylint, flake8,
+    black, pylint, flake8, yamllint
     py{26,27,36,37,38},
     custom
 skipsdist = true
@@ -161,6 +161,10 @@ whitelist_externals =
 commands =
     bash {toxinidir}/.travis/runflake8.sh {envpython} --statistics {posargs} .
 
+[testenv:yamllint]
+deps = yamllint
+commands = yamllint .
+
 [testenv:coveralls]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:coveralls}
 passenv = TRAVIS TRAVIS_*
@@ -265,6 +269,6 @@ python =
   2.6: py26,custom
   2.7: py27,flake8,pylint,custom
   3.5: coveralls,custom
-  3.6: py36,black,custom
+  3.6: py36,black,yamllint,custom
   3.7: py37,custom
   3.8: py38,custom


### PR DESCRIPTION
~~Update to the new molecule linter config. Also move the yamllint config
to the repo root directory to make it possible to use yamllint directly.~~
Changed it to only contain the yamllint config change and an update to tox to let it run yamllint.