### PR TITLE
Coverage: Use find and file module instead of shell command

### DIFF
--- a/tests/get-coverage.yml
+++ b/tests/get-coverage.yml
@@ -37,8 +37,18 @@
         state: absent
         path: "{{ coverage_file }}"
 
+    - name: find coverage files to delete
+      find:
+        path: "{{ playbook_dir }}"
+        patterns: ".coverage.*"
+        hidden: yes
+      register: files_to_delete
+
     - name: remove old data
-      shell: rm -f .coverage.*
+      file:
+        path: "{{ item.path }}"
+        state: absent
+      with_items: "{{ files_to_delete.files }}"
 
     - name: copy coveragerc
       copy:


### PR DESCRIPTION
While understanding module encountered warning !!
Therefore Removed

Deprecated warning 

'use of command - shell: rm -f .coverage.*'

using Ansible module file, find



