### PR TITLE
sync with latest template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
     - python: 3.6
     - python: 3.7
     - python: 3.8
+    - python: 3.8-dev
 
 services:
   - docker

--- a/.travis/custom.sh
+++ b/.travis/custom.sh
@@ -16,12 +16,7 @@ TOPDIR=$(readlink -f ${SCRIPTDIR}/..)
 . ${SCRIPTDIR}/utils.sh
 . ${SCRIPTDIR}/config.sh
 
-# Sanitize arguments (see https://github.com/tox-dev/tox/issues/1463):
-ENVPYTHON=$(readlink -f $1)
-SYSPYTHON=$(readlink -f $2)
-shift 2
-
 # Write your custom commands here that should be run when `tox -e custom`:
-if [[ -z "${TRAVIS}" ]] || lsr_check_python_version ${ENVPYTHON} -eq '3.6'; then
+if [[ -z "${TRAVIS}" ]] || lsr_check_python_version python -eq '3.6'; then
   (set -x; cd ${TOPDIR}/tests; ${ENVPYTHON} ./ensure_non_running_provider.py)
 fi

--- a/.travis/preinstall
+++ b/.travis/preinstall
@@ -20,6 +20,11 @@ if lsr_venv_python_matches_system_python; then
   LSR_EXTRA_PACKAGES='python3-selinux'
 fi
 
+# extra packages needed with python 2.6 and ansible 2.6
+if lsr_check_python_version python -lt 2.7 ; then
+  LSR_EXTRA_PACKAGES="$LSR_EXTRA_PACKAGES libffi-dev libssl-dev"
+fi
+
 . ${SCRIPTDIR}/config.sh
 
 # Install extra dependencies.

--- a/.travis/runblack.sh
+++ b/.travis/runblack.sh
@@ -5,8 +5,7 @@
 # is to get a user the opportunity to control black from config.sh via setting
 # environment variables.
 
-# The first script argument is a path to Python interpreter, the rest of
-# arguments are passed to black.
+# The given command line arguments are passed to black.
 
 # Environment variables:
 #
@@ -20,6 +19,9 @@
 #
 #   RUN_BLACK_DISABLED
 #     if set to an arbitrary non-empty value, black will be not executed
+#
+#   RUN_BLACK_EXTRA_ARGS
+#     extra cmd line args to pass to black
 
 set -e
 
@@ -33,11 +35,6 @@ if [[ "${RUN_BLACK_DISABLED}" ]]; then
   lsr_info "${ME}: black is disabled. Skipping."
   exit 0
 fi
-
-# Sanitize path in case if running within tox (see
-# https://github.com/tox-dev/tox/issues/1463):
-ENVPYTHON=$(readlink -f $1)
-shift
 
 DEFAULT_INCLUDE='^[^.].*\.py$'
 DEFAULT_EXCLUDE='/(\.[^.].*|tests/roles)/'
@@ -64,7 +61,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 set -x
-${ENVPYTHON} -m black \
+python -m black \
   --include "${INCLUDE_ARG:-${RUN_BLACK_INCLUDE:-${DEFAULT_INCLUDE}}}" \
   --exclude "${EXCLUDE_ARG:-${RUN_BLACK_EXCLUDE:-${DEFAULT_EXCLUDE}}}" \
+  ${RUN_BLACK_EXTRA_ARGS:-} \
   "${OTHER_ARGS[@]}"

--- a/.travis/runcoveralls.sh
+++ b/.travis/runcoveralls.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+# Reports coverage results using coveralls. The aim of this script is to
+# provide a unified way to reporting coverage results across all linux system
+# roles projects.
+
+# The given command line arguments are passed to coveralls.
+
+# Environment variables:
+#
+#   LSR_PUBLISH_COVERAGE
+#     if the variable is empty or unset, nothing will be published; if the
+#     variable has its value set to 'strict', the reporting is performed in
+#     strict mode, so situations like missing data to be reported are treated
+#     as errors; if the value of this variable is 'debug', coveralls is run in
+#     debug mode (see coveralls debug --help); other values cause that coverage
+#     results will be reported normally
+#   LSR_TESTSDIR
+#     a path to directory where tests and tests artifacts are located; if unset
+#     or empty, this variable is set to ${TOPDIR}/tests; this path should
+#     already exists and be populated with tests artifacts before the script
+#     starts performing actions on it
+
+set -e
+
+ME=$(basename $0)
+SCRIPTDIR=$(readlink -f $(dirname $0))
+
+. ${SCRIPTDIR}/utils.sh
+. ${SCRIPTDIR}/config.sh
+
+# Publish the results only if it is desired.
+if [[ -z "${LSR_PUBLISH_COVERAGE}" ]]; then
+  lsr_info "${ME}: Publishing coverage report is not enabled. Skipping."
+  exit 0
+fi
+
+LSR_TESTSDIR=${LSR_TESTSDIR:-${TOPDIR}/tests}
+
+# Ensure we are in $LSR_TESTSDIR. It is supposed that if a user wants to submit
+# tests results, $LSR_TESTSDIR always exists.
+cd ${LSR_TESTSDIR}
+
+# For simplicity, we suppose that coverage core data file has name .coverage
+# and it is situated in $LSR_TESTSDIR. Similarly for .coveragerc.
+COVERAGEFILE='.coverage'
+COVERAGERCFILE='.coveragerc'
+
+# In case there is no $COVERAGEFILE, there is nothing to report. If we are
+# running in strict mode, treat this situation as error.
+if [[ ! -s ${COVERAGEFILE} ]]; then
+  NO_COVERAGEFILE_MSG="${COVERAGEFILE} is missing or empty"
+  if [[ "${LSR_PUBLISH_COVERAGE}" == "strict" ]]; then
+    lsr_error "${ME} (strict mode): ${NO_COVERAGEFILE_MSG}!"
+  fi
+  lsr_info "${ME}: ${NO_COVERAGEFILE_MSG}, nothing to publish."
+  exit 0
+fi
+
+# Create $COVERAGERCFILE file with a [paths] section. From the official docs:
+#
+#   The first value must be an actual file path on the machine where the
+#   reporting will happen, so that source code can be found. The other values
+#   can be file patterns to match against the paths of collected data, or they
+#   can be absolute or relative file paths on the current machine.
+#
+# So in our $COVERAGERCFILE file we make both locations to point to the
+# project's top directory.
+cat > ${COVERAGERCFILE} <<EOF
+[paths]
+source =
+    ..
+    $(readlink -f ..)
+EOF
+
+# Rename $COVERAGEFILE to ${COVERAGEFILE}.merge. With this trick, coverage
+# combine applies configuration in $COVERAGERCFILE also to $COVERAGEFILE.
+mv ${COVERAGEFILE} ${COVERAGEFILE}.merge
+python -m coverage combine --append
+
+MAYBE_DEBUG=""
+if [[ "${LSR_PUBLISH_COVERAGE}" == "debug" ]]; then
+  MAYBE_DEBUG=debug
+fi
+
+set -x
+coveralls ${MAYBE_DEBUG} "$@"

--- a/.travis/runflake8.sh
+++ b/.travis/runflake8.sh
@@ -4,13 +4,14 @@
 # A shell wrapper around flake8. The purpose of this wrapper is to get to user
 # an opportunity to disable running flake8 via config.sh.
 
-# The first script argument is a path to Python interpreter, the rest of
-# arguments are passed to flake8.
+# The given command line arguments are passed to flake8.
 
 # Environment variables:
 #
 #   RUN_FLAKE8_DISABLED
 #     if set to an arbitrary non-empty value, flake8 will be not executed
+#   RUN_FLAKE8_IGNORE
+#     list of issues to ignore - see flake8 docs
 
 set -e
 
@@ -25,10 +26,7 @@ if [[ "${RUN_FLAKE8_DISABLED}" ]]; then
   exit 0
 fi
 
-# Sanitize path in case if running within tox (see
-# https://github.com/tox-dev/tox/issues/1463):
-ENVPYTHON=$(readlink -f $1)
-shift
-
 set -x
-${ENVPYTHON} -m flake8 "$@"
+python -m flake8 \
+  ${RUN_FLAKE8_IGNORE:+--ignore} ${RUN_FLAKE8_IGNORE:-} \
+  "$@"

--- a/.travis/runpylint.sh
+++ b/.travis/runpylint.sh
@@ -10,20 +10,15 @@
 #       which set them by including config.sh). Now, they take effect also when
 #       running tox locally.
 
-# First argument to the script is a path to environment python, the rest of
-# arguments are passed to custom_pylint.py.
+# The given command line arguments are passed to custom_pylint.py.
 
 set -e
 
 ME=$(basename $0)
 SCRIPTDIR=$(readlink -f $(dirname $0))
 
+. ${SCRIPTDIR}/utils.sh
 . ${SCRIPTDIR}/config.sh
 
-# Sanitize path in case if running within tox (see
-# https://github.com/tox-dev/tox/issues/1463):
-ENVPYTHON=$(readlink -f $1)
-shift
-
 set -x
-${ENVPYTHON} ${SCRIPTDIR}/custom_pylint.py "$@"
+python ${SCRIPTDIR}/custom_pylint.py "$@"

--- a/.travis/runpytest.sh
+++ b/.travis/runpytest.sh
@@ -8,26 +8,20 @@
 # running pytest if there are no unit tests and filters out --cov*/--no-cov*
 # arguments if there is nothing to be analyzed with coverage.
 
-# First argument to the script is a path to environment python, the rest of
-# arguments are passed to pytest.
+# The given command line arguments are passed to pytest.
 
 set -e
 
 ME=$(basename $0)
 SCRIPTDIR=$(readlink -f $(dirname $0))
-TOPDIR=$(readlink -f ${SCRIPTDIR}/..)
 
 . ${SCRIPTDIR}/utils.sh
+. ${SCRIPTDIR}/config.sh
 
 if [[ ! -d ${TOPDIR}/tests/unit ]]; then
   lsr_info "${ME}: No unit tests found. Skipping."
   exit 0
 fi
-
-# Sanitize path in case if running within tox (see
-# https://github.com/tox-dev/tox/issues/1463):
-ENVPYTHON=$(readlink -f $1)
-shift
 
 PYTEST_OPTS=()
 PYTEST_OPTS_NOCOV=()
@@ -58,4 +52,4 @@ if [[ "${USE_COV}" == "no" ]]; then
 fi
 
 set -x
-${ENVPYTHON} -m pytest "${PYTEST_OPTS[@]}"
+python -m pytest "${PYTEST_OPTS[@]}"

--- a/.travis/runsyspycmd.sh
+++ b/.travis/runsyspycmd.sh
@@ -5,26 +5,18 @@
 # to system python libraries, especially C bindings. The script is run with
 # these arguments:
 #
-#   $1     - path to environment python
-#   $2     - path to system python
-#   $3     - command runnable in Python (should be present in $PATH)
-#   ${@:4} - arguments passed to $3
+#   $1     - command runnable in Python (should be present in $PATH)
+#   ${@:2} - arguments passed to $1
 
 set -e
 
 ME=$(basename $0)
 SCRIPTDIR=$(readlink -f $(dirname $0))
-TOPDIR=$(readlink -f ${SCRIPTDIR}/..)
 
 . ${SCRIPTDIR}/utils.sh
 . ${SCRIPTDIR}/config.sh
 
-# Sanitize arguments (see https://github.com/tox-dev/tox/issues/1463):
-ENVPYTHON=$(readlink -f $1)
-SYSPYTHON=$(readlink -f $2)
-shift 2
-
-if ! lsr_venv_python_matches_system_python ${ENVPYTHON} ${SYSPYTHON}; then
+if ! lsr_venv_python_matches_system_python ; then
   lsr_info "${ME}: ${1:-<missing command>}:" \
     "Environment Python has no access to system Python libraries. Skipping."
   exit 0
@@ -34,4 +26,4 @@ COMMAND=$(command -v $1)
 shift
 
 set -x
-${ENVPYTHON} ${COMMAND} "$@"
+python ${COMMAND} "$@"

--- a/.travis/utils.sh
+++ b/.travis/utils.sh
@@ -136,14 +136,61 @@ function lsr_compare_pythons() {
 }
 
 ##
+# lsr_get_system_python
+#
+# Return the system python, or /usr/bin/python3 if nothing
+# else can be found in a standard location.
+function lsr_get_system_python() {
+  local syspython=$(command -pv python3)
+  if [[ -z "$syspython" ]]; then
+    syspython=$(command -pv python)
+  fi
+  if [[ -z "$syspython" ]]; then
+    syspython=$(command -pv python2)
+  fi
+  echo ${syspython:-/usr/bin/python3}
+}
+
+##
 # lsr_venv_python_matches_system_python [$1] [$2]
 #
 #   $1 - command or full path to venv Python interpreter (default: python)
 #   $2 - command or full path to the system Python interpreter
-#        (default: /usr/bin/python3)
+#        (default: /usr/bin/python3 or /usr/bin/python or /usr/bin/python2)
 #
 # Exit with 0 if virtual environment Python version matches the system Python
 # version.
 function lsr_venv_python_matches_system_python() {
-  lsr_compare_pythons ${1:-python} -eq ${2:-/usr/bin/python3}
+  local syspython="${2:-$(lsr_get_system_python)}"
+
+  lsr_compare_pythons ${1:-python} -eq $syspython
 }
+
+##
+# lsr_setup_module_utils [$1] [$2]
+#
+#   $1 - path to the ansible/module_utils/ directory in the venv
+#        assumes ansible has been installed in the venv
+#        defaults to env var $SRC_MODULE_UTILS_DIR
+#   $2 - path to the local module_utils/ directory for the role
+#        defaults to env var $DEST_MODULE_UTILS_DIR
+#
+# Exit with 0 if virtual environment Python version matches the system Python
+# version.
+function lsr_setup_module_utils() {
+  local srcdir=${1:-$SRC_MODULE_UTILS_DIR}
+  local destdir=${2:-$DEST_MODULE_UTILS_DIR}
+  if [ -n "$srcdir" -a -d "$srcdir" -a -n "$destdir" -a -d "$destdir" ]; then
+    bash $TOPDIR/tests/setup_module_utils.sh "$srcdir" "$destdir"
+  fi
+}
+
+# set TOPDIR
+ME=${ME:-$(basename $0)}
+SCRIPTDIR=${SCRIPTDIR:-$(readlink -f $(dirname $0))}
+TOPDIR=$(readlink -f ${SCRIPTDIR}/..)
+
+# Local Variables:
+# mode: Shell-script
+# sh-basic-offset: 2
+# End:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,14 +1,17 @@
 # SPDX-License-Identifier: MIT
 ---
-ignore: |
-  /.tox/
-extends: default
-rules:
-  braces:
-    max-spaces-inside: 1
-    level: error
-  brackets:
-    max-spaces-inside: 1
-    level: error
-  truthy: disable
-  document-start: disable
+extends: .yamllint_defaults.yml
+# possible customizations over the base yamllint config
+# skip the yaml files in the /tests/ directory
+# NOTE: If you want to customize `ignore` you'll have to
+# copy in all of the config from .yamllint.yml, then
+# add your own - so if you want to just add /tests/ to
+# be ignored, you'll have to add the ignores from the base
+# ignore: |
+#   /tests/
+#   /.tox/
+# skip checking line length
+# NOTE: the above does not apply to `rules` - you do not
+# have to copy all of the rules from the base config
+# rules:
+#   line-length: disable

--- a/.yamllint_defaults.yml
+++ b/.yamllint_defaults.yml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MIT
+---
+ignore: |
+  /.tox/
+extends: default
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  truthy: disable
+  document-start: disable

--- a/ansible26_requirements.txt
+++ b/ansible26_requirements.txt
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+
+# extra requirements for installing ansible 26
+idna<2.8
+PyYAML<5.1
+ansible<2.7

--- a/pytest26_extra_requirements.txt
+++ b/pytest26_extra_requirements.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+
+# Write extra requirements for running pytest with python2.6 here:
+# NOTE: If your pytests need ansible, use the requirements from
+# ansible26_requirements.txt, either by listing it like this:
+# -ransible26_requirements.txt
+# or by listing the dependencies from that file explicitly

--- a/pytest_extra_requirements.txt
+++ b/pytest_extra_requirements.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MIT
+
+# Write extra requirements for running pytest here:
+# NOTE: for python 2.6 environments, use pytest26_extra_requirements.txt
+# if your pytests need ansible, add ansible here

--- a/tests/setup_module_utils.sh
+++ b/tests/setup_module_utils.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ -n "${DEBUG:-}" ] ; then
+    set -x
+fi
+
+if [ ! -d "${1:-}" ] ; then
+    echo Either ansible is not installed, or there is no ansible/module_utils
+    echo in $1 - Skipping
+    exit 0
+fi
+
+if [ ! -d "${2:-}" ] ; then
+    echo Role has no module_utils - Skipping
+    exit 0
+fi
+
+# we need absolute path for $2
+absmoddir=$( readlink -f "$2" )
+
+# clean up old links to module_utils
+for item in "$1"/* ; do
+    if lnitem=$( readlink "$item" ) && test -n "$lnitem" ; then
+        case "$lnitem" in
+            *"${2}"*) rm -f "$item" ;;
+        esac
+    fi
+done
+
+# add new links to module_utils
+for item in "$absmoddir"/* ; do
+    case "$item" in
+        *__pycache__) continue;;
+        *.pyc) continue;;
+    esac
+    bnitem=$( basename "$item" )
+    ln -s "$item" "$1/$bnitem"
+done

--- a/tox.ini
+++ b/tox.ini
@@ -13,15 +13,18 @@ basepython = python3
 deps =
     py{26,27,36,37,38}: pytest-cov
     py{27,36,37,38}: pytest>=3.5.1
+    py{27,36,37,38}: -rpytest_extra_requirements.txt
     py{26,27}: mock
     py26: pytest
+    py26: -rpytest26_extra_requirements.txt
 
 [base]
-system_python = /usr/bin/python3
 passenv = *
 setenv =
     PYTHONPATH = {toxinidir}/library:{toxinidir}/module_utils
     LC_ALL = C
+    SRC_MODULE_UTILS_DIR = {envsitepackagesdir}/ansible/module_utils
+    DEST_MODULE_UTILS_DIR = {toxinidir}/module_utils
 changedir = {toxinidir}/tests
 covtargets = --cov={toxinidir}/library --cov={toxinidir}/module_utils
 pytesttarget = unit
@@ -43,7 +46,7 @@ changedir = {[base]changedir}
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {[base]runpytest} {envpython} \
+    bash {[base]runpytest} \
          --durations=5 \
          {[base]covtargets} \
          --cov-report=html:htmlcov-py26 \
@@ -61,7 +64,7 @@ changedir = {[base]changedir}
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {[base]runpytest} {envpython} \
+    bash {[base]runpytest} \
          --durations=5 \
          {[base]covtargets} \
          --cov-report=html:htmlcov-py27 \
@@ -79,7 +82,7 @@ changedir = {[base]changedir}
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {[base]runpytest} {envpython} \
+    bash {[base]runpytest} \
          --durations=5 \
          {[base]covtargets} \
          --cov-report=html:htmlcov-py36 \
@@ -97,7 +100,7 @@ changedir = {[base]changedir}
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {[base]runpytest} {envpython} \
+    bash {[base]runpytest} \
          --durations=5 \
          {[base]covtargets} \
          --cov-report=html:htmlcov-py37 \
@@ -115,7 +118,7 @@ changedir = {[base]changedir}
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {[base]runpytest} {envpython} \
+    bash {[base]runpytest} \
          --durations=5 \
          {[base]covtargets} \
          --cov-report=html:htmlcov-py38 \
@@ -132,7 +135,7 @@ deps =
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {toxinidir}/.travis/runblack.sh {envpython} --check --diff .
+    bash {toxinidir}/.travis/runblack.sh --check --diff .
 
 [testenv:pylint]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:2.7}
@@ -141,14 +144,14 @@ passenv = RUN_PYLINT_*
 setenv =
     {[base]setenv}
 deps =
+    ansible
     colorama
     pylint>=1.8.4
-    ansible
     -rpylint_extra_requirements.txt
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {toxinidir}/.travis/runpylint.sh {envpython} --errors-only {posargs}
+    bash {toxinidir}/.travis/runpylint.sh --errors-only {posargs}
 
 [testenv:flake8]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:2.7}
@@ -159,7 +162,7 @@ deps =
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {toxinidir}/.travis/runflake8.sh {envpython} --statistics {posargs} .
+    bash {toxinidir}/.travis/runflake8.sh --exclude=.venv,.tox --statistics {posargs} .
 
 [testenv:yamllint]
 deps = yamllint
@@ -168,13 +171,13 @@ commands = yamllint .
 [testenv:coveralls]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:coveralls}
 passenv = TRAVIS TRAVIS_*
-whitelist_externals = bash
 deps =
     coveralls
 changedir = {[base]changedir}
+whitelist_externals =
+    {[base]whitelist_externals}
 commands =
-    bash -c 'cd ..; bash .travis/fix-coverage.sh; cd -'
-    coveralls
+    bash {toxinidir}/.travis/runcoveralls.sh {posargs}
 
 [molecule_common]
 deps =
@@ -192,10 +195,8 @@ deps =
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {[molecule_common]runsyspycmd} {envpython} {[base]system_python} \
-         molecule --version
-    bash {[molecule_common]runsyspycmd} {envpython} {[base]system_python} \
-         ansible --version
+    bash {[molecule_common]runsyspycmd} molecule --version
+    bash {[molecule_common]runsyspycmd} ansible --version
 
 [testenv:molecule_lint]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:molecule}
@@ -204,7 +205,7 @@ deps =
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {[molecule_common]runsyspycmd} {envpython} {[base]system_python} \
+    bash {[molecule_common]runsyspycmd} \
          molecule lint -s {env:LSR_MSCENARIO:default} {posargs}
 
 [testenv:molecule_syntax]
@@ -214,7 +215,7 @@ deps =
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {[molecule_common]runsyspycmd} {envpython} {[base]system_python} \
+    bash {[molecule_common]runsyspycmd} \
          molecule syntax -s {env:LSR_MSCENARIO:default} {posargs}
 
 [testenv:molecule_test]
@@ -224,7 +225,7 @@ deps =
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {[molecule_common]runsyspycmd} {envpython} {[base]system_python} \
+    bash {[molecule_common]runsyspycmd} \
          molecule test -s {env:LSR_MSCENARIO:default} {posargs}
 
 [testenv:molecule]
@@ -247,7 +248,7 @@ passenv = *
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {toxinidir}/.travis/custom.sh {envpython} {[base]system_python}
+    bash {toxinidir}/.travis/custom.sh
 
 [pytest]
 addopts = -rxs


### PR DESCRIPTION
Just use the `python` command in the virtual environment, instead
of using `envpython`.  This solves some problems where the
attempt to resolve the `envpython` to the `syspython` by following
symlinks causes python not to be able find some packages installed
in the venv.

Add support for python 3.8-dev in travis.

Do not install ansible by default in all tox venvs for pytest
tests.  If the user needs to install ansible for pytests, the
user will add `ansible` to the new `pytest_extra_requirements.txt`
For python 2.6, which requires ansible 2.6, there is a special
`pytest26_extra_requirements.txt`, and an example
`ansible26_requirements.txt` which the user will use to specify
the extra dependencies for installing ansible 2.6 on python 2.6.

There are two extra dependencies added to the list of dependencies
installed on the travis machines when using python 2.6 - libffi-dev
and libssl-dev - these are required in order to install ansible 2.6
and its extra dependencies.

For python 2.6, an older version of tox must be used, which does not
have support for `commands_pre`, so allow `tests/setup_module_utils.sh`
to be run directly from `.travis/runpytest.sh` on those platforms.
the user will select to install ansible

Use the file `.yamllint_defaults.yml` for the base `yamllint`
configuration.  User customizations go into `.yamllint.yml`, which
extends `.yamllint_defaults.yml`.  This allows the use of `yamllint`
with IDEs that do not allow specifying command line arguments
for the `yamllint` command.

Only run coveralls in travis in the py35 environment.

