### PR TITLE
python 2.6 support for pytest and ansible 2.6

### DIFF
--- a/.travis/preinstall
+++ b/.travis/preinstall
@@ -20,6 +20,11 @@ if lsr_venv_python_matches_system_python; then
   LSR_EXTRA_PACKAGES='python3-selinux'
 fi
 
+# extra packages needed with python 2.6 and ansible 2.6
+if lsr_check_python_version python -lt 2.7 ; then
+  LSR_EXTRA_PACKAGES="$LSR_EXTRA_PACKAGES libffi-dev libssl-dev"
+fi
+
 . ${SCRIPTDIR}/config.sh
 
 # Install extra dependencies.

--- a/ansible_pytest_extra_requirements.txt
+++ b/ansible_pytest_extra_requirements.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+
+# ansible and dependencies for all supported platforms
+ansible ; python_version > "2.6"
+ansible<2.7 ; python_version < "2.7"
+idna<2.8 ; python_version < "2.7"
+PyYAML<5.1 ; python_version < "2.7"

--- a/pytest_extra_requirements.txt
+++ b/pytest_extra_requirements.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+
+# Write extra requirements for running pytest here:
+# If you need ansible then uncomment the following line:
+#-ransible_pytest_extra_requirements.txt
+# If you need mock then uncomment the following line:
+mock ; python_version < "3.0"

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ basepython = python3
 deps =
     py{26,27,36,37,38}: pytest-cov
     py{27,36,37,38}: pytest>=3.5.1
-    py{26,27}: mock
     py26: pytest
+    py{26,27,36,37,38}: -rpytest_extra_requirements.txt
 
 [base]
 system_python = /usr/bin/python3


### PR DESCRIPTION
This doesn't affect network because network does not use ansible
for pyunit testing, so this commit is primarily to be in sync with
the template and other repos.

However, if you need `ansible` and `mock` for unit testing or
linting, see `pytest_extra_requirements.txt`