### PR TITLE
allow more overrides of template code

### DIFF
--- a/.travis/runblack.sh
+++ b/.travis/runblack.sh
@@ -19,6 +19,9 @@
 #
 #   RUN_BLACK_DISABLED
 #     if set to an arbitrary non-empty value, black will be not executed
+#
+#   RUN_BLACK_EXTRA_ARGS
+#     extra cmd line args to pass to black
 
 set -e
 
@@ -61,4 +64,5 @@ set -x
 python -m black \
   --include "${INCLUDE_ARG:-${RUN_BLACK_INCLUDE:-${DEFAULT_INCLUDE}}}" \
   --exclude "${EXCLUDE_ARG:-${RUN_BLACK_EXCLUDE:-${DEFAULT_EXCLUDE}}}" \
+  ${RUN_BLACK_EXTRA_ARGS:-} \
   "${OTHER_ARGS[@]}"

--- a/.travis/runflake8.sh
+++ b/.travis/runflake8.sh
@@ -10,6 +10,9 @@
 #
 #   RUN_FLAKE8_DISABLED
 #     if set to an arbitrary non-empty value, flake8 will be not executed
+#
+#   RUN_FLAKE8_EXTRA_ARGS
+#     any extra command line arguments to provide e.g. --ignore=some,errs
 
 set -e
 
@@ -25,4 +28,4 @@ if [[ "${RUN_FLAKE8_DISABLED}" ]]; then
 fi
 
 set -x
-python -m flake8 "$@"
+python -m flake8 ${RUN_FLAKE8_EXTRA_ARGS:-} "$@"

--- a/.travis/runpytest.sh
+++ b/.travis/runpytest.sh
@@ -14,7 +14,6 @@ set -e
 
 ME=$(basename $0)
 SCRIPTDIR=$(readlink -f $(dirname $0))
-TOPDIR=$(readlink -f ${SCRIPTDIR}/..)
 
 . ${SCRIPTDIR}/utils.sh
 

--- a/.travis/runsyspycmd.sh
+++ b/.travis/runsyspycmd.sh
@@ -12,7 +12,6 @@ set -e
 
 ME=$(basename $0)
 SCRIPTDIR=$(readlink -f $(dirname $0))
-TOPDIR=$(readlink -f ${SCRIPTDIR}/..)
 
 . ${SCRIPTDIR}/utils.sh
 . ${SCRIPTDIR}/config.sh

--- a/.travis/utils.sh
+++ b/.travis/utils.sh
@@ -168,3 +168,13 @@ function lsr_venv_python_matches_system_python() {
 
   lsr_compare_pythons ${1:-python} -eq $syspython
 }
+
+# set TOPDIR
+ME=${ME:-$(basename $0)}
+SCRIPTDIR=${SCRIPTDIR:-$(readlink -f $(dirname $0))}
+TOPDIR=$(readlink -f ${SCRIPTDIR}/..)
+
+# Local Variables:
+# mode: Shell-script
+# sh-basic-offset: 2
+# End:


### PR DESCRIPTION
NOTE: I don't think this commit directly affects network, since
network doesn't use any of these - this PR is more for parity
with template and other repos.

Centralize the setting of `ME` and `TOPDIR` in utils.sh

Add support for `RUN_FLAKE8_EXTRA_ARGS` and `RUN_BLACK_EXTRA_ARGS`