### PR TITLE
library: Separate debug and info logs from warnings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,6 +64,10 @@
     ignore_errors: "{{ network_ignore_errors | default(omit) }}"
     force_state_change: "{{ network_force_state_change | default(omit) }}"
     connections: "{{ network_connections | default([]) }}"
+  register: __network_connections_result
+
+- name: Show debug messages
+  debug: var=__network_connections_result
 
 - name: Re-test connectivity
   ping:

--- a/tests/playbooks/tests_ethernet.yml
+++ b/tests/playbooks/tests_ethernet.yml
@@ -37,6 +37,8 @@
           address: 192.0.2.1/24
   roles:
     - linux-system-roles.network
+  tasks:
+    - include_tasks: tasks/assert_output_in_stderr_without_warnings.yml
 
 - hosts: all
   tasks:

--- a/tests/playbooks/tests_reapply.yml
+++ b/tests/playbooks/tests_reapply.yml
@@ -50,7 +50,7 @@
         - name: Assert that reapply is found in log output
           assert:
             fail_msg: Reapply not found in log output
-            that: "{{ 'connection reapplied' in test_module_run.warnings[2] }}"
+            that: "{{ 'connection reapplied' in test_module_run.stderr }}"
       always:
         - block:
             # Use internal module directly for speedup

--- a/tests/tasks/assert_output_in_stderr_without_warnings.yml
+++ b/tests/tasks/assert_output_in_stderr_without_warnings.yml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: BSD-3-Clause
+---
+- name: "Assert that warnings is empty"
+  assert:
+    that:
+      - "'warnings' not in __network_connections_result"
+    msg: "There are unexpected warnings"
+- name: "Assert that there is output in stderr"
+  assert:
+    that:
+      - "'stderr' in __network_connections_result"
+    msg: "There are no messages in stderr"

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -4,3 +4,9 @@
   hosts: all
   roles:
     - linux-system-roles.network
+  tasks:
+    - name: Test warning and info logs
+      assert:
+        that:
+          - "'warnings' not in __network_connections_result"
+        msg: "There are warnings"


### PR DESCRIPTION
Logs are now separed by severity level. Warnings and Failures are treated like
before, but debug and info logs are saved into a new json parameter called
"info_debug" that is later shown by a new created task.

In order to achieve a better readability, debug and info logs are shown as
warnings in case of failure like before, and also in "info_debug". If there is
not any failure, debug and info logs are never shown as warnings.

Signed-off-by: Elvira Garcia Ruiz <elviragr@riseup.net>