### PR TITLE
use selectattr instead of json_query

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,7 @@ network_provider: "{{ network_provider_current }}"
 
 # wpa_supplicant is required if any ieee802_1x connections are defined
 wpa_supplicant_required: "{{ network_connections |
-      json_query('[*][ieee802_1x]') | flatten | count > 0 }}"
+      selectattr('ieee802_1x', 'defined') | list | count > 0 }}"
 _network_packages_default_802_1x: ["{% if wpa_supplicant_required
       %}wpa_supplicant{% endif %}"]
 


### PR DESCRIPTION
Some tests were getting the following error:
```
Unexpected templating type error occurred on ({{
     network_connections |
       json_query('[*][ieee802_1x]') | flatten | count > 0 }}): 'NoneType'
       object is not iterable"
```
In general it is better to avoid the use of `json_query` and use
the older built-in jinaj2 filters such as `selectattr`, unless you
need to perform a complex query of complex json data.  In this
case, not sure what the problem was with the input json, but
using `selectattr` seems to have fixed it.