### PR TITLE
Install gobject on travis

### DIFF
--- a/.travis/config.sh
+++ b/.travis/config.sh
@@ -6,6 +6,11 @@
 #   * .travis/preinstall:
 #
 #       - LSR_EXTRA_PACKAGES
+
+if lsr_venv_python_matches_system_python; then
+  LSR_EXTRA_PACKAGES="${LSR_EXTRA_PACKAGES} python3-gi libnm0"
+fi
+
 #
 #   * .travis/runtox:
 #

--- a/tox.ini
+++ b/tox.ini
@@ -273,3 +273,4 @@ python =
   3.6: py36,coveralls,black,yamllint,custom
   3.7: py37,coveralls,custom
   3.8: py38,coveralls,custom
+  3.8-dev: py38,coveralls,custom


### PR DESCRIPTION
    Some unit tests are skipped when pygobject is missing. This leads to
    wrongly reported coverage data.  Install the libraries to improve here.
