### PR TITLE
tox: Move common options to testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,27 +8,32 @@ skipsdist = true
 skip_missing_interpreters = true
 
 [testenv]
-basepython = python3
-# List common dependencies for Python interpreters here:
-deps =
-    py{26,27,36,37,38}: pytest-cov
-    py{27,36,37,38}: pytest>=3.5.1
-    py26: pytest
-    py{26,27,36,37,38}: -rpytest_extra_requirements.txt
-
-[base]
 passenv = *
+basepython = python3
+changedir = {toxinidir}/tests
+# List common dependencies for Python interpreters here:
 setenv =
     PYTHONPATH = {toxinidir}/library:{toxinidir}/module_utils
     LC_ALL = C
     SRC_MODULE_UTILS_DIR = {envsitepackagesdir}/ansible/module_utils
     DEST_MODULE_UTILS_DIR = {toxinidir}/module_utils
-changedir = {toxinidir}/tests
-covtargets = --cov={toxinidir}/library --cov={toxinidir}/module_utils
-pytesttarget = unit
+deps =
+    py{26,27,36,37,38}: pytest-cov
+    py{27,36,37,38}: pytest>=3.5.1
+    py26: pytest
+    py{26,27,36,37,38}: -rpytest_extra_requirements.txt
 whitelist_externals =
     bash
-runpytest = {toxinidir}/.travis/runpytest.sh
+commands =
+    bash {toxinidir}/.travis/runpytest.sh \
+         --durations=5 \
+         --cov={toxinidir}/library --cov={toxinidir}/module_utils \
+         --cov-report=html:htmlcov-{envname} \
+         --cov-report=term \
+         {posargs} \
+         unit
+
+[base]
 
 [testenv:py26]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:2.6}
@@ -37,101 +42,30 @@ install_command =
 list_dependencies_command =
     pip freeze
 basepython = python2.6
-passenv = {[base]passenv}
-setenv =
-    {[base]setenv}
-changedir = {[base]changedir}
-whitelist_externals =
-    {[base]whitelist_externals}
-commands =
-    bash {[base]runpytest} \
-         --durations=5 \
-         {[base]covtargets} \
-         --cov-report=html:htmlcov-py26 \
-         --cov-report=term \
-         {posargs} \
-         {[base]pytesttarget}
 
 [testenv:py27]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:2.7}
 basepython = python2.7
-passenv = {[base]passenv}
-setenv =
-    {[base]setenv}
-changedir = {[base]changedir}
-whitelist_externals =
-    {[base]whitelist_externals}
-commands =
-    bash {[base]runpytest} \
-         --durations=5 \
-         {[base]covtargets} \
-         --cov-report=html:htmlcov-py27 \
-         --cov-report=term \
-         {posargs} \
-         {[base]pytesttarget}
 
 [testenv:py36]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:3.6}
 basepython = python3.6
-passenv = {[base]passenv}
-setenv =
-    {[base]setenv}
-changedir = {[base]changedir}
-whitelist_externals =
-    {[base]whitelist_externals}
-commands =
-    bash {[base]runpytest} \
-         --durations=5 \
-         {[base]covtargets} \
-         --cov-report=html:htmlcov-py36 \
-         --cov-report=term \
-         {posargs} \
-         {[base]pytesttarget}
 
 [testenv:py37]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:3.7}
 basepython = python3.7
-passenv = {[base]passenv}
-setenv =
-    {[base]setenv}
-changedir = {[base]changedir}
-whitelist_externals =
-    {[base]whitelist_externals}
-commands =
-    bash {[base]runpytest} \
-         --durations=5 \
-         {[base]covtargets} \
-         --cov-report=html:htmlcov-py37 \
-         --cov-report=term \
-         {posargs} \
-         {[base]pytesttarget}
 
 [testenv:py38]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:3.8}
 basepython = python3.8
-passenv = {[base]passenv}
-setenv =
-    {[base]setenv}
-changedir = {[base]changedir}
-whitelist_externals =
-    {[base]whitelist_externals}
-commands =
-    bash {[base]runpytest} \
-         --durations=5 \
-         {[base]covtargets} \
-         --cov-report=html:htmlcov-py38 \
-         --cov-report=term \
-         {posargs} \
-         {[base]pytesttarget}
 
 [testenv:black]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:3.6}
 basepython = python3.6
 passenv = RUN_BLACK_*
+changedir = {toxinidir}
 deps =
     black
-whitelist_externals =
-    {[base]whitelist_externals}
 commands =
     bash {toxinidir}/.travis/runblack.sh --check --diff .
 
@@ -139,15 +73,12 @@ commands =
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:2.7}
 basepython = python2.7
 passenv = RUN_PYLINT_*
-setenv =
-    {[base]setenv}
+changedir = {toxinidir}
 deps =
     ansible
     colorama
     pylint>=1.8.4
     -rpylint_extra_requirements.txt
-whitelist_externals =
-    {[base]whitelist_externals}
 commands =
     bash {toxinidir}/.travis/runpylint.sh --errors-only {posargs}
 
@@ -155,14 +86,14 @@ commands =
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:2.7}
 basepython = python2.7
 passenv = RUN_FLAKE8_*
+changedir = {toxinidir}
 deps =
     flake8>=3.5
-whitelist_externals =
-    {[base]whitelist_externals}
 commands =
     bash {toxinidir}/.travis/runflake8.sh {posargs} .
 
 [testenv:yamllint]
+changedir = {toxinidir}
 deps = yamllint
 commands = yamllint .
 
@@ -171,13 +102,11 @@ envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:coveralls}
 passenv = TRAVIS TRAVIS_*
 deps =
     coveralls
-changedir = {[base]changedir}
-whitelist_externals =
-    {[base]whitelist_externals}
 commands =
     bash {toxinidir}/.travis/runcoveralls.sh {posargs}
 
 [molecule_common]
+changedir = {toxinidir}
 deps =
     {env:LSR_ANSIBLE_DEP:ansible}
     docker
@@ -187,51 +116,46 @@ deps =
 runsyspycmd = {toxinidir}/.travis/runsyspycmd.sh
 
 [testenv:molecule_version]
+changedir = {[molecule_common]changedir}
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:molecule}
 deps =
     {[molecule_common]deps}
-whitelist_externals =
-    {[base]whitelist_externals}
 commands =
     bash {[molecule_common]runsyspycmd} molecule --version
     bash {[molecule_common]runsyspycmd} ansible --version
 
 [testenv:molecule_lint]
+changedir = {[molecule_common]changedir}
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:molecule}
 deps =
     {[molecule_common]deps}
-whitelist_externals =
-    {[base]whitelist_externals}
 commands =
     bash {[molecule_common]runsyspycmd} \
          molecule lint -s {env:LSR_MSCENARIO:default} {posargs}
 
 [testenv:molecule_syntax]
+changedir = {[molecule_common]changedir}
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:molecule}
 deps =
     {[molecule_common]deps}
-whitelist_externals =
-    {[base]whitelist_externals}
 commands =
     bash {[molecule_common]runsyspycmd} \
          molecule syntax -s {env:LSR_MSCENARIO:default} {posargs}
 
 [testenv:molecule_test]
+changedir = {[molecule_common]changedir}
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:molecule}
 deps =
     {[molecule_common]deps}
-whitelist_externals =
-    {[base]whitelist_externals}
 commands =
     bash {[molecule_common]runsyspycmd} \
          molecule test -s {env:LSR_MSCENARIO:default} {posargs}
 
 [testenv:molecule]
+changedir = {[molecule_common]changedir}
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:molecule}
 deps =
     {[molecule_common]deps}
-whitelist_externals =
-    {[base]whitelist_externals}
 commands =
     {[testenv:molecule_version]commands}
     {[testenv:molecule_lint]commands}
@@ -239,12 +163,10 @@ commands =
     {[testenv:molecule_test]commands}
 
 [testenv:custom]
+changedir = {toxinidir}
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:custom}
 deps =
     -rcustom_requirements.txt
-passenv = *
-whitelist_externals =
-    {[base]whitelist_externals}
 commands =
     bash {toxinidir}/.travis/custom.sh
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ changedir = {toxinidir}/tests
 # List common dependencies for Python interpreters here:
 setenv =
     PYTHONPATH = {toxinidir}/library:{toxinidir}/module_utils
-    LC_ALL = C
+    LC_ALL = C.UTF-8
     SRC_MODULE_UTILS_DIR = {envsitepackagesdir}/ansible/module_utils
     DEST_MODULE_UTILS_DIR = {toxinidir}/module_utils
 deps =


### PR DESCRIPTION
Move several common options to testenv instead of base to simplify the
file and use normal tox inheritance.

There is probably more potential for simplification but these seem to be some easy cases.