### PR TITLE
tasks: Check directly if NetworkManager is running

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,13 +10,7 @@ network_provider_os_default: "{{
       'OracleLinux'
     ] and ansible_distribution_major_version is version('7', '<')
     else 'nm' }}"
-# If NetworkManager.service is running, assume that 'nm' is currently in-use,
-# otherwise initscripts
-__network_provider_current: "{{
-    'nm' if 'NetworkManager.service' in ansible_facts.services and
-        ansible_facts.services['NetworkManager.service']['state'] == 'running'
-        else 'initscripts'
-    }}"
+__network_provider_current: "{{ __network_current_provider.stdout }}"
 # Default to the auto-detected value
 network_provider: "{{ __network_provider_current }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # get service facts, used in defaults/main.yml
 ---
-- name: Check which services are running
-  service_facts:
-  no_log: true
+# If NetworkManager is running, assume that 'nm' is currently in-use,
+# otherwise initscripts
+- name: Get current provider
+  shell: |
+    for f in /proc/*/exe;
+    do [[ "$(readlink -f "${f}")" == /usr/sbin/NetworkManager ]] \
+      && echo nm && break
+    done || echo -n initscripts
+  register: __network_current_provider
+  when: true
 
 # needed for ansible_facts.packages
 - name: Check which packages are installed


### PR DESCRIPTION
The service_facts module broke for Fedora 32. Instead of relying on it,
just check directly if NetworkManager is running to determine if it is
the current provider.

closes #218