### PR TITLE
Document setting bond options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This role can be used to configure:
 - Ethernet interfaces
 - Bridge interfaces
 - Bonded interfaces
-- VLAN  interfaces
+- VLAN interfaces
 - MacVLAN interfaces
 - Infiniband interfaces
 - IP configuration
@@ -466,6 +466,22 @@ SSL certificates and keys must be deployed on the host prior to running the role
   * `domain_suffix_match`
 
     If set, NetworkManager will ensure the domain name of the EAP server certificate matches this string.
+
+### `bond`
+
+The `bond` setting configures the options of bonded interfaces
+(type `bond`). It supports the following options:
+
+  * `mode`
+
+    Bonding mode.  See the
+    [kernel documentation](https://www.kernel.org/doc/Documentation/networking/bonding.txt)
+    or your distribution `nmcli` documentation for valid values.
+    NetworkManager defaults to `balance-rr`.
+
+  * `miimon`
+
+    Sets the MII link monitoring interval (in milliseconds)
 
 Examples of Options
 -------------------

--- a/examples/bond_simple.yml
+++ b/examples/bond_simple.yml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: BSD-3-Clause
+---
+- hosts: network-test
+  vars:
+    network_connections:
+
+      # Create a bond master
+      - name: bond0
+        state: up
+        type: bond
+        interface_name: bond0
+        # bond configuration settings: (optional)
+        bond:
+          mode: active-backup
+          miimon: 110
+
+      # enslave an ethernet to the bond
+      - name: slave1
+        state: up
+        type: ethernet
+        interface_name: eth1
+        master: bond0
+
+      # enslave a second ethernet to the bond
+      - name: slave2
+        state: up
+        type: ethernet
+        interface_name: eth2
+        master: bond0
+
+  roles:
+    - linux-system-roles.network
+...


### PR DESCRIPTION
There was no documentation of the supported bond options.
Added supported options to the README.md and added an example of a
simple bond with both of those options.

Resolves #220