### PR TITLE
library: Change ethtool features to use underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,57 +357,57 @@ kernel and device, changing some features might not be supported.
 ```yaml
   ethtool:
     features:
-      esp-hw-offload: yes|no  # optional
-      esp-tx-csum-hw-offload: yes|no  # optional
-      fcoe-mtu: yes|no  # optional
+      esp_hw_offload: yes|no  # optional
+      esp_tx_csum_hw_offload: yes|no  # optional
+      fcoe_mtu: yes|no  # optional
       gro: yes|no  # optional
       gso: yes|no  # optional
       highdma: yes|no  # optional
-      hw-tc-offload: yes|no  # optional
-      l2-fwd-offload: yes|no  # optional
+      hw_tc_offload: yes|no  # optional
+      l2_fwd_offload: yes|no  # optional
       loopback: yes|no  # optional
       lro: yes|no  # optional
       ntuple: yes|no  # optional
       rx: yes|no  # optional
-      rx-all: yes|no  # optional
-      rx-fcs: yes|no  # optional
-      rx-gro-hw: yes|no  # optional
-      rx-udp_tunnel-port-offload: yes|no  # optional
-      rx-vlan-filter: yes|no  # optional
-      rx-vlan-stag-filter: yes|no  # optional
-      rx-vlan-stag-hw-parse: yes|no  # optional
+      rx_all: yes|no  # optional
+      rx_fcs: yes|no  # optional
+      rx_gro_hw: yes|no  # optional
+      rx_udp_tunnel_port_offload: yes|no  # optional
+      rx_vlan_filter: yes|no  # optional
+      rx_vlan_stag_filter: yes|no  # optional
+      rx_vlan_stag_hw_parse: yes|no  # optional
       rxhash: yes|no  # optional
       rxvlan: yes|no  # optional
       sg: yes|no  # optional
-      tls-hw-record: yes|no  # optional
-      tls-hw-tx-offload: yes|no  # optional
+      tls_hw_record: yes|no  # optional
+      tls_hw_tx_offload: yes|no  # optional
       tso: yes|no  # optional
       tx: yes|no  # optional
-      tx-checksum-fcoe-crc: yes|no  # optional
-      tx-checksum-ip-generic: yes|no  # optional
-      tx-checksum-ipv4: yes|no  # optional
-      tx-checksum-ipv6: yes|no  # optional
-      tx-checksum-sctp: yes|no  # optional
-      tx-esp-segmentation: yes|no  # optional
-      tx-fcoe-segmentation: yes|no  # optional
-      tx-gre-csum-segmentation: yes|no  # optional
-      tx-gre-segmentation: yes|no  # optional
-      tx-gso-partial: yes|no  # optional
-      tx-gso-robust: yes|no  # optional
-      tx-ipxip4-segmentation: yes|no  # optional
-      tx-ipxip6-segmentation: yes|no  # optional
-      tx-nocache-copy: yes|no  # optional
-      tx-scatter-gather: yes|no  # optional
-      tx-scatter-gather-fraglist: yes|no  # optional
-      tx-sctp-segmentation: yes|no  # optional
-      tx-tcp-ecn-segmentation: yes|no  # optional
-      tx-tcp-mangleid-segmentation: yes|no  # optional
-      tx-tcp-segmentation: yes|no  # optional
-      tx-tcp6-segmentation: yes|no  # optional
-      tx-udp-segmentation: yes|no  # optional
-      tx-udp_tnl-csum-segmentation: yes|no  # optional
-      tx-udp_tnl-segmentation: yes|no  # optional
-      tx-vlan-stag-hw-insert: yes|no  # optional
+      tx_checksum_fcoe_crc: yes|no  # optional
+      tx_checksum_ip_generic: yes|no  # optional
+      tx_checksum_ipv4: yes|no  # optional
+      tx_checksum_ipv6: yes|no  # optional
+      tx_checksum_sctp: yes|no  # optional
+      tx_esp_segmentation: yes|no  # optional
+      tx_fcoe_segmentation: yes|no  # optional
+      tx_gre_csum_segmentation: yes|no  # optional
+      tx_gre_segmentation: yes|no  # optional
+      tx_gso_partial: yes|no  # optional
+      tx_gso_robust: yes|no  # optional
+      tx_ipxip4_segmentation: yes|no  # optional
+      tx_ipxip6_segmentation: yes|no  # optional
+      tx_nocache_copy: yes|no  # optional
+      tx_scatter_gather: yes|no  # optional
+      tx_scatter_gather_fraglist: yes|no  # optional
+      tx_sctp_segmentation: yes|no  # optional
+      tx_tcp_ecn_segmentation: yes|no  # optional
+      tx_tcp_mangleid_segmentation: yes|no  # optional
+      tx_tcp_segmentation: yes|no  # optional
+      tx_tcp6_segmentation: yes|no  # optional
+      tx_udp_segmentation: yes|no  # optional
+      tx_udp_tnl_csum_segmentation: yes|no  # optional
+      tx_udp_tnl_segmentation: yes|no  # optional
+      tx_vlan_stag_hw_insert: yes|no  # optional
       txvlan: yes|no  # optional
 ```
 

--- a/examples/ethtool_features.yml
+++ b/examples/ethtool_features.yml
@@ -16,4 +16,4 @@
               features:
                 gro: "no"
                 gso: "yes"
-                tx-sctp-segmentation: "no"
+                tx_sctp_segmentation: "no"

--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -369,6 +369,7 @@ class IfcfgUtil:
         ethtool_features = connection["ethtool"]["features"]
         configured_features = []
         for feature, setting in ethtool_features.items():
+            feature = feature.replace("_", "-")
             value = ""
             if setting:
                 value = "on"

--- a/module_utils/network_lsr/nm_provider.py
+++ b/module_utils/network_lsr/nm_provider.py
@@ -17,7 +17,7 @@ def get_nm_ethtool_feature(name):
         :rtype: str
     """
 
-    name = ETHTOOL_FEATURE_PREFIX + name.upper().replace("-", "_")
+    name = ETHTOOL_FEATURE_PREFIX + name.upper()
 
     feature = getattr(Util.NM(), name, None)
     return feature

--- a/tests/playbooks/tests_ethtool_features.yml
+++ b/tests/playbooks/tests_ethtool_features.yml
@@ -79,6 +79,72 @@
               - >-
                   'tx-tcp-segmentation: off' in
                   ethtool_features.stdout_lines | map('trim')
+        - name: >-
+            TEST: I can enable tx_tcp_segmentation (using underscores).
+          debug:
+            msg: "##################################################"
+        - import_role:
+            name: linux-system-roles.network
+          vars:
+            network_connections:
+              - name: "{{ interface }}"
+                state: up
+                type: ethernet
+                ip:
+                  dhcp4: "no"
+                  auto6: "no"
+                ethtool:
+                  features:
+                    tx_tcp_segmentation: "yes"
+        - name: Get current device features
+          command: "ethtool --show-features {{ interface }}"
+          register: ethtool_features
+        - name:
+          debug:
+            var: ethtool_features.stdout_lines
+        - name: Assert device features
+          assert:
+            that:
+              - >-
+                  'tx-tcp-segmentation: on' in
+                  ethtool_features.stdout_lines | map('trim')
+        - name: I cannot change tx_tcp_segmentation and tx-tcp-segmentation at
+                the same time.
+          block:
+            - name: >-
+                TEST: Change feature with both underscores and dashes.
+              debug:
+                msg: "##################################################"
+            - network_connections:
+                provider: "{{ network_provider | mandatory }}"
+                connections:
+                  - name: "{{ interface }}"
+                    state: up
+                    type: ethernet
+                    ip:
+                      dhcp4: "no"
+                      auto6: "no"
+                    ethtool:
+                      features:
+                        tx_tcp_segmentation: "no"
+                        tx-tcp-segmentation: "no"
+              register: __network_connections_result
+          rescue:
+            - name: Show network_connections result
+              debug:
+                var: __network_connections_result
+            - assert:
+                that:
+                  - '{{  "fatal error: configuration error:
+                      connections[0].ethtool.features: duplicate key
+                      ''tx_tcp_segmentation''" in
+                      __network_connections_result.msg }}'
+          always:
+            - name: Check failure
+              debug:
+                var: __network_connections_result
+            - assert:
+                that: "{{ __network_connections_result.failed == true }}"
         - name: "TEST: I can reset features to their original value."
           debug:
             msg: "##################################################"

--- a/tests/unit/test_nm_provider.py
+++ b/tests/unit/test_nm_provider.py
@@ -27,5 +27,5 @@ with mock.patch.dict("sys.modules", {"gi": mock.Mock(), "gi.repository": mock.Mo
 def test_get_nm_ethtool_feature():
     """ Test get_nm_ethtool_feature() """
     with mock.patch.object(nm_provider.Util, "NM") as nm_mock:
-        nm_feature = nm_provider.get_nm_ethtool_feature("esp-hw-offload")
+        nm_feature = nm_provider.get_nm_ethtool_feature("esp_hw_offload")
     assert nm_feature == nm_mock.return_value.ETHTOOL_OPTNAME_FEATURE_ESP_HW_OFFLOAD


### PR DESCRIPTION
Ethtool features should use underscores instead of dashes. A
warning shows in case dashes used, and it fails if underscore and dashes are
mixed.