### PR TITLE
Fail if state and persistent_state are incompatible

### DIFF
--- a/module_utils/network_lsr/argument_validator.py
+++ b/module_utils/network_lsr/argument_validator.py
@@ -1064,14 +1064,18 @@ class ArgValidator_DictConnection(ArgValidatorDict):
         """
         actions = []
         state = result.get("state")
-        if state in self.VALID_PERSISTENT_STATES:
-            del result["state"]
-            persistent_state_default = state
-            state = None
-        else:
-            persistent_state_default = None
+        persistent_state = result.get("persistent_state")
 
-        persistent_state = result.get("persistent_state", persistent_state_default)
+        if state in self.VALID_PERSISTENT_STATES:
+            if persistent_state:
+                raise ValidationError(
+                    name,
+                    "State cannot be '{0}' if persistent_state is specified".format(
+                        state
+                    ),
+                )
+            persistent_state = state
+            state = None
 
         # default persistent_state to present (not done via default_value in the
         # ArgValidatorStr, the value will only be set at the end of

--- a/tests/playbooks/tests_802_1x.yml
+++ b/tests/playbooks/tests_802_1x.yml
@@ -42,7 +42,7 @@
             network_connections:
               - name: "{{ interface }}"
                 persistent_state: absent
-                state: absent
+                state: down
         - name: >-
             TEST: 802.1x profile with unencrypted private key,
             domain suffix match, and system ca certs
@@ -85,7 +85,7 @@
             network_connections:
               - name: "{{ interface }}"
                 persistent_state: absent
-                state: absent
+                state: down
 
         - include_tasks: tasks/test_802.1x_capath.yml
       always:

--- a/tests/unit/test_network_connections.py
+++ b/tests/unit/test_network_connections.py
@@ -2986,6 +2986,22 @@ class TestValidator(unittest.TestCase):
             ):
                 assert validator.deprecated_by in validators.keys()
 
+    def test_valid_persistent_state(self):
+        """
+        Test that when persistent_state is present and state is set to present
+        or absent, a ValidationError raises.
+        """
+        validator = network_lsr.argument_validator.ArgValidator_DictConnection()
+        input_connection = {
+            "name": "test",
+            "persistent_state": "present",
+            "state": "present",
+            "type": "ethernet",
+        }
+        self.assertValidationError(validator, input_connection)
+        input_connection.update({"state": "absent"})
+        self.assertValidationError(validator, input_connection)
+
 
 @my_test_skipIf(nmutil is None, "no support for NM (libnm via pygobject)")
 class TestNM(unittest.TestCase):


### PR DESCRIPTION
When persistent_state is present and state is set to present or absent, a
ValidationError raises. A unit test validating this has been added.

Ref #205 

Signed-off-by: Elvira Garcia Ruiz <elviragr@riseup.net>