### PR TITLE
Fix ca_path test

### DIFF
--- a/tests/tasks/test_802.1x_capath.yml
+++ b/tests/tasks/test_802.1x_capath.yml
@@ -79,13 +79,15 @@
         - __NM_capath_ignored_NVRs
 
     - name: Assert role behavior
+      vars:
+        expected_failure: __network_NM_NVR.stdout in __NM_capath_ignored_NVRs
+        failure: __network_connections_result.failed
       assert:
-        that: __network_connections_result.failed ==
-          (__network_NM_NVR.stdout in __NM_capath_ignored_NVRs)
-        msg: "Role {{ __network_connections_result.failed and 'failed'
-            or 'did not fail' }} but was expected
-            {{ (__network_NM_NVR.stdout in __NM_capath_ignored_NVRs)
-            and '' or 'not' }} to fail. NM NVR: {{ __network_NM_NVR.stdout }}"
+        that: (failure and expected_failure) or
+          (not failure and not expected_failure)
+        msg: "Role {{ failure and 'failed' or 'did not fail' }} but was expected
+          {{ expected_failure and '' or 'not' }} to fail.
+          NM NVR: {{ __network_NM_NVR.stdout }}"
 
     - name: Assert ping succeeded
       assert:

--- a/tests/tasks/test_802.1x_capath.yml
+++ b/tests/tasks/test_802.1x_capath.yml
@@ -88,6 +88,14 @@
         msg: "Role {{ failure and 'failed' or 'did not fail' }} but was expected
           {{ expected_failure and '' or 'not' }} to fail.
           NM NVR: {{ __network_NM_NVR.stdout }}"
+    - name: Assert role failure
+      assert:
+        that: "
+          'ieee802_1x.ca_path specified but not supported by NetworkManager'
+          in __network_connections_result.stderr"
+      when:
+        - __network_connections_result.failed
+
 
     - name: Assert ping succeeded
       assert:


### PR DESCRIPTION
this addresses #245 and adds a proper check for the reason the role failed.