### PR TITLE
library: Rename invocation return value

### DIFF
--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -1599,7 +1599,7 @@ class RunEnvironmentAnsible(RunEnvironment):
         kwargs["warnings"] = warning_logs
         stderr = "\n".join(debug_logs) + "\n"
         kwargs["stderr"] = stderr
-        kwargs["invocation"] = {"params": self.module.params}
+        kwargs["_invocation"] = {"module_args": self.module.params}
         return kwargs
 
     def exit_json(self, connections, changed=False, **kwargs):


### PR DESCRIPTION
Since `invocation` is an Ansible special value that is set for
triple verbosity, it is now visible for smaller verbosity. Therefore
rename it to `_invocation`, which seems to work with less verbosity.
Also adjust the content to match the regular `invocation` style.