### PR TITLE
Provider sets: Always run essential tasks

### DIFF
--- a/tests/ensure_provider_tests.py
+++ b/tests/ensure_provider_tests.py
@@ -23,6 +23,8 @@ GET_NM_VERSION = """
           when: true
       when:
         - ansible_distribution_major_version != '6'
+      tags:
+        - always
 """
 
 MINIMUM_NM_VERSION_CHECK = """
@@ -41,6 +43,8 @@ RUN_PLAYBOOK_WITH_NM = """# SPDX-License-Identifier: BSD-3-Clause
     - name: Set network provider to 'nm'
       set_fact:
         network_provider: nm
+      tags:
+        - always
 {get_nm_version}
 
 # workaround for: https://github.com/ansible/ansible/issues/27973
@@ -86,6 +90,8 @@ RUN_PLAYBOOK_WITH_INITSCRIPTS = """# SPDX-License-Identifier: BSD-3-Clause
     - name: Set network provider to 'initscripts'
       set_fact:
         network_provider: initscripts
+      tags:
+        - always
 
 - import_playbook: {test_playbook}
 """

--- a/tests/tests_802_1x_nm.yml
+++ b/tests/tests_802_1x_nm.yml
@@ -8,6 +8,8 @@
     - name: Set network provider to 'nm'
       set_fact:
         network_provider: nm
+      tags:
+        - always
 
 
 # workaround for: https://github.com/ansible/ansible/issues/27973

--- a/tests/tests_802_1x_updated_nm.yml
+++ b/tests/tests_802_1x_updated_nm.yml
@@ -8,6 +8,8 @@
     - name: Set network provider to 'nm'
       set_fact:
         network_provider: nm
+      tags:
+        - always
 
 
 # workaround for: https://github.com/ansible/ansible/issues/27973

--- a/tests/tests_bridge_initscripts.yml
+++ b/tests/tests_bridge_initscripts.yml
@@ -7,5 +7,7 @@
     - name: Set network provider to 'initscripts'
       set_fact:
         network_provider: initscripts
+      tags:
+        - always
 
 - import_playbook: playbooks/tests_bridge.yml

--- a/tests/tests_bridge_nm.yml
+++ b/tests/tests_bridge_nm.yml
@@ -8,6 +8,8 @@
     - name: Set network provider to 'nm'
       set_fact:
         network_provider: nm
+      tags:
+        - always
 
 
 # workaround for: https://github.com/ansible/ansible/issues/27973

--- a/tests/tests_ethernet_initscripts.yml
+++ b/tests/tests_ethernet_initscripts.yml
@@ -7,5 +7,7 @@
     - name: Set network provider to 'initscripts'
       set_fact:
         network_provider: initscripts
+      tags:
+        - always
 
 - import_playbook: playbooks/tests_ethernet.yml

--- a/tests/tests_ethernet_nm.yml
+++ b/tests/tests_ethernet_nm.yml
@@ -8,6 +8,8 @@
     - name: Set network provider to 'nm'
       set_fact:
         network_provider: nm
+      tags:
+        - always
 
 
 # workaround for: https://github.com/ansible/ansible/issues/27973

--- a/tests/tests_ethtool_features_nm.yml
+++ b/tests/tests_ethtool_features_nm.yml
@@ -8,6 +8,8 @@
     - name: Set network provider to 'nm'
       set_fact:
         network_provider: nm
+      tags:
+        - always
 
     - block:
         - name: Install NetworkManager
@@ -22,6 +24,8 @@
           when: true
       when:
         - ansible_distribution_major_version != '6'
+      tags:
+        - always
 
 
 # workaround for: https://github.com/ansible/ansible/issues/27973

--- a/tests/tests_reapply_nm.yml
+++ b/tests/tests_reapply_nm.yml
@@ -8,6 +8,8 @@
     - name: Set network provider to 'nm'
       set_fact:
         network_provider: nm
+      tags:
+        - always
 
 
 # workaround for: https://github.com/ansible/ansible/issues/27973

--- a/tests/tests_states_nm.yml
+++ b/tests/tests_states_nm.yml
@@ -8,6 +8,8 @@
     - name: Set network provider to 'nm'
       set_fact:
         network_provider: nm
+      tags:
+        - always
 
 
 # workaround for: https://github.com/ansible/ansible/issues/27973

--- a/tests/tests_vlan_mtu_initscripts.yml
+++ b/tests/tests_vlan_mtu_initscripts.yml
@@ -7,5 +7,7 @@
     - name: Set network provider to 'initscripts'
       set_fact:
         network_provider: initscripts
+      tags:
+        - always
 
 - import_playbook: playbooks/tests_vlan_mtu.yml

--- a/tests/tests_vlan_mtu_nm.yml
+++ b/tests/tests_vlan_mtu_nm.yml
@@ -8,6 +8,8 @@
     - name: Set network provider to 'nm'
       set_fact:
         network_provider: nm
+      tags:
+        - always
 
 
 # workaround for: https://github.com/ansible/ansible/issues/27973

--- a/tests/tests_wireless_nm.yml
+++ b/tests/tests_wireless_nm.yml
@@ -8,6 +8,8 @@
     - name: Set network provider to 'nm'
       set_fact:
         network_provider: nm
+      tags:
+        - always
 
 
 # workaround for: https://github.com/ansible/ansible/issues/27973


### PR DESCRIPTION
To allow selecting tests with tags, tasks essential tasks need to be
tagged as always to ensure that they are not accidentally skipped when
specifying a tag for a test.