### PR TITLE
Simplify persistent state handling

### DIFF
--- a/module_utils/network_lsr/argument_validator.py
+++ b/module_utils/network_lsr/argument_validator.py
@@ -1083,10 +1083,6 @@ class ArgValidator_DictConnection(ArgValidatorDict):
         if not persistent_state:
             persistent_state = "present"
 
-        # If the profile is present, it should be ensured first
-        if persistent_state == "present":
-            actions.append(persistent_state)
-
         # If the profile should be absent at the end, it needs to be present in
         # the meantime to allow to (de)activate it. This is only possible if it
         # is completely defined, for which `type` needs to be specified.
@@ -1094,13 +1090,11 @@ class ArgValidator_DictConnection(ArgValidatorDict):
         if persistent_state == "absent" and state and result.get("type"):
             actions.append("present")
 
+        actions.append(persistent_state)
+
         # Change the runtime state if necessary
         if state:
             actions.append(state)
-
-        # Remove the profile in the end if requested
-        if persistent_state == "absent":
-            actions.append(persistent_state)
 
         result["state"] = state
         result["persistent_state"] = persistent_state

--- a/tests/unit/test_network_connections.py
+++ b/tests/unit/test_network_connections.py
@@ -2794,7 +2794,7 @@ class TestValidator(unittest.TestCase):
     def test_state_absent_up_no_type(self):
         self.check_partial_connection_zero(
             {"name": "eth0", "persistent_state": "absent", "state": "up"},
-            {"actions": ["up", "absent"], "persistent_state": "absent", "state": "up"},
+            {"actions": ["absent", "up"], "persistent_state": "absent", "state": "up"},
         )
 
     def test_state_absent_up_type(self):
@@ -2807,7 +2807,7 @@ class TestValidator(unittest.TestCase):
                 "type": "ethernet",
             },
             {
-                "actions": ["present", "up", "absent"],
+                "actions": ["present", "absent", "up"],
                 "persistent_state": "absent",
                 "state": "up",
             },
@@ -2818,7 +2818,7 @@ class TestValidator(unittest.TestCase):
         self.check_partial_connection_zero(
             {"name": "eth0", "persistent_state": "absent", "state": "down"},
             {
-                "actions": ["down", "absent"],
+                "actions": ["absent", "down"],
                 "persistent_state": "absent",
                 "state": "down",
             },


### PR DESCRIPTION
Since the order of the actions list does not matter anymore because the
role iterates over all actions in a defined order, simplify the
handling for persistent states.