### PR TITLE
molecule: Hardcode ansible-lint version

### DIFF
--- a/molecule_extra_requirements.txt
+++ b/molecule_extra_requirements.txt
@@ -2,3 +2,4 @@
 
 # Write extra requirements for running molecule here:
 jmespath
+ansible-lint==4.2.0


### PR DESCRIPTION
This fixes the following traceback:

Traceback (most recent call last):
[...]
  File "/home/travis/build/linux-system-roles/network/.tox/env-3.6/lib/python3.6/site-packages/ansiblelint/utils.py", line 775, in expand_path_vars
    path = path.strip()
AttributeError: 'PosixPath' object has no attribute 'strip'

Reference: https://travis-ci.com/github/linux-system-roles/network/jobs/373270149