### PR TITLE
Tasks: Explicitly specify file mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,6 +72,7 @@
   copy:
     dest: /etc/sysconfig/network
     content: "# Created by network system role"
+    mode: "0644"
     force: false
   when:
     - network_provider == "initscripts"


### PR DESCRIPTION
Ansible with molecule warns because the default mode changed. The new
default mode seems to be wrong so specify the correct one.