### PR TITLE
Molecule: Unpin ansible-lint version

### DIFF
--- a/molecule_extra_requirements.txt
+++ b/molecule_extra_requirements.txt
@@ -2,4 +2,3 @@
 
 # Write extra requirements for running molecule here:
 jmespath
-ansible-lint==4.2.0


### PR DESCRIPTION
The latest ansible-lint version was broken, now it works again.
Therefore, unpin it.