### PR TITLE
tests: Do not check arch for NM version

### DIFF
--- a/tests/playbooks/tests_states.yml
+++ b/tests/playbooks/tests_states.yml
@@ -122,14 +122,14 @@
               # FIXME: This needs to be included before lsr_assert_when but
               # after the role ran to ensure that NetworkManager is actually
               # installed but it is not an assert.
-              - tasks/get_NetworkManager_NVRA.yml
+              - tasks/get_NetworkManager_NVR.yml
             lsr_assert_when:
               - what: tasks/assert_device_absent.yml
                 # NetworkManager 1.18.4 from CentOS does not seem to remove the
                 # virtual interface in this case but it seems to work with
-                # 1:NetworkManager-1.27.0-26129.d0a2eb8f05.el7.x86_64
+                # 1:NetworkManager-1.27.0-26129.d0a2eb8f05.el7
                 when: "{{ network_provider == 'nm' and
-                  NetworkManager_NVRA != 'NetworkManager-1.18.4-3.el7.x86_64'
+                  NetworkManager_NVR != 'NetworkManager-1.18.4-3.el7'
                   }}"
             lsr_cleanup:
               - tasks/cleanup_profile+device.yml

--- a/tests/tasks/get_NetworkManager_NVR.yml
+++ b/tests/tasks/get_NetworkManager_NVR.yml
@@ -3,17 +3,17 @@
 - block:
     - name: Get NetworkManager RPM version
       command:
-        cmd: rpm -qa NetworkManager
+        cmd: rpm -qa --qf '%{name}-%{version}-%{release}\n' NetworkManager
         warn: false
-      register: __rpm_qa_NetworkManager
+      register: __rpm_q_NetworkManager
 
     - name: Store NetworkManager version
       set_fact:
-        NetworkManager_NVRA: "{{ __rpm_qa_NetworkManager.stdout }}"
+        NetworkManager_NVR: "{{ __rpm_q_NetworkManager.stdout }}"
 
     - name: Show NetworkManager version
       debug:
-        var: NetworkManager_NVRA
+        var: NetworkManager_NVR
   tags:
     - always
 ...


### PR DESCRIPTION
To allow running the tests on any arch, do not check for the RPM
architecture when checking the NetworkManager version.

Signed-off-by: Till Maas <opensource@till.name>