### PR TITLE
use github_branch: main for galaxy import

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,6 +6,7 @@ galaxy_info:
   company: Red Hat, Inc.
   license: BSD-3-Clause
   min_ansible_version: 2.7
+  github_branch: main
   galaxy_tags:
     - centos
     - fedora


### PR DESCRIPTION
Galaxy imports of the network role are failing:
https://galaxy.ansible.com/my-imports/1710
```
Task "703539" failed: Command '['git', 'clone', '--quiet', '--depth', '1', '--branch', 'master', 'https://github.com/linux-system-roles/network.git', '/var/tmp/galaxy/imports/tmpnxdxwzmg']' returned non-zero exit status 128.
```
We need to tell galaxy to use `main` instead of `master`.  The galaxy
roles documentation says that `github_branch` may be used for this
purpose:
https://galaxy.ansible.com/docs/contributing/creating_role.html#role-metadata