### PR TITLE
nm provider: Refactor the down action of network connection

### DIFF
--- a/module_utils/network_lsr/nm/__init__.py
+++ b/module_utils/network_lsr/nm/__init__.py
@@ -1,0 +1,9 @@
+# Relative import is not support by ansible 2.8 yet
+# pylint: disable=import-error, no-name-in-module
+from ansible.module_utils.network_lsr.nm.provider import (  # noqa:E501
+    NetworkManagerProvider,
+)
+
+# pylint: enable=import-error, no-name-in-module
+
+NetworkManagerProvider

--- a/module_utils/network_lsr/nm/active_connection.py
+++ b/module_utils/network_lsr/nm/active_connection.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Handle NM.ActiveConnection
+
+import logging
+
+# Relative import is not support by ansible 2.8 yet
+# pylint: disable=import-error, no-name-in-module
+from ansible.module_utils.network_lsr.nm.client import GLib  # noqa:E501
+from ansible.module_utils.network_lsr.nm.client import NM  # noqa:E501
+from ansible.module_utils.network_lsr.nm.client import get_mainloop  # noqa:E501
+from ansible.module_utils.network_lsr.nm.client import get_client  # noqa:E501
+from ansible.module_utils.network_lsr.nm.error import LsrNetworkNmError  # noqa:E501
+
+# pylint: enable=import-error, no-name-in-module
+
+
+NM_AC_STATE_CHANGED_SIGNAL = "state-changed"
+
+
+def deactivate_active_connection(nm_ac, timeout, check_mode):
+    if not nm_ac or nm_ac.props.state == NM.ActiveConnectionState.DEACTIVATED:
+        logging.info("Connection is not active, no need to deactivate")
+        return False
+    if not check_mode:
+        main_loop = get_mainloop(timeout)
+        logging.debug(
+            "Deactivating {id} with timeout {timeout}".format(
+                id=nm_ac.get_id(), timeout=timeout
+            )
+        )
+        user_data = main_loop
+        handler_id = nm_ac.connect(
+            NM_AC_STATE_CHANGED_SIGNAL, _nm_ac_state_change_callback, user_data
+        )
+        logging.debug(
+            "Registered {signal} on NM.ActiveConnection {id}".format(
+                signal=NM_AC_STATE_CHANGED_SIGNAL, id=nm_ac.get_id()
+            )
+        )
+        if nm_ac.props.state != NM.ActiveConnectionState.DEACTIVATING:
+            nm_client = get_client()
+            user_data = (main_loop, nm_ac, nm_ac.get_id(), handler_id)
+            nm_client.deactivate_connection_async(
+                nm_ac,
+                main_loop.cancellable,
+                _nm_ac_deactivate_call_back,
+                user_data,
+            )
+            logging.debug("Deactivating NM.ActiveConnection {0}".format(nm_ac.get_id()))
+        main_loop.run()
+    return True
+
+
+def _nm_ac_state_change_callback(nm_ac, state, reason, user_data):
+    main_loop = user_data
+    if main_loop.is_cancelled:
+        return
+    logging.debug(
+        "Got NM.ActiveConnection state change: {id}: {state} {reason}".format(
+            id=nm_ac.get_id(), state=state, reason=reason
+        )
+    )
+    if nm_ac.props.state == NM.ActiveConnectionState.DEACTIVATED:
+        logging.debug("NM.ActiveConnection {0} is deactivated".format(nm_ac.get_id()))
+        main_loop.quit()
+
+
+def _nm_ac_deactivate_call_back(nm_client, result, user_data):
+    main_loop, nm_ac, nm_ac_id, handler_id = user_data
+    logging.debug("NM.ActiveConnection deactivating callback")
+    if main_loop.is_cancelled:
+        if nm_ac:
+            nm_ac.handler_disconnect(handler_id)
+        return
+
+    try:
+        success = nm_client.deactivate_connection_finish(result)
+    except GLib.Error as e:
+        if e.matches(NM.ManagerError.quark(), NM.ManagerError.CONNECTIONNOTACTIVE):
+            logging.info(
+                "Connection is not active on {0}, no need to deactivate".format(
+                    nm_ac_id
+                )
+            )
+            if nm_ac:
+                nm_ac.handler_disconnect(handler_id)
+            main_loop.quit()
+            return
+        else:
+            _deactivate_fail(
+                main_loop,
+                handler_id,
+                nm_ac,
+                "Failed to deactivate connection {id}, error={error}".format(
+                    id=nm_ac_id, error=e
+                ),
+            )
+            return
+    except Exception as e:
+        _deactivate_fail(
+            main_loop,
+            handler_id,
+            nm_ac,
+            "Failed to deactivate connection {id}, error={error}".format(
+                id=nm_ac_id, error=e
+            ),
+        )
+        return
+
+    if not success:
+        _deactivate_fail(
+            main_loop,
+            handler_id,
+            nm_ac,
+            "Failed to deactivate connection {0}, error='None "
+            "returned from deactivate_connection_finish()'".format(nm_ac_id),
+        )
+
+
+def _deactivate_fail(main_loop, handler_id, nm_ac, msg):
+    if nm_ac:
+        nm_ac.handler_disconnect(handler_id)
+    logging.error(msg)
+    main_loop.fail(LsrNetworkNmError(msg))

--- a/module_utils/network_lsr/nm/client.py
+++ b/module_utils/network_lsr/nm/client.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+import logging
+
+# Relative import is not support by ansible 2.8 yet
+# pylint: disable=import-error, no-name-in-module
+from ansible.module_utils.network_lsr.nm.error import LsrNetworkNmError  # noqa:E501
+
+import gi
+
+gi.require_version("NM", "1.0")
+
+# It is required to state the NM version before importing it
+# But this break the flake8 rule: https://www.flake8rules.com/rules/E402.html
+# Use NOQA: E402 to suppress it.
+from gi.repository import NM  # NOQA: E402
+from gi.repository import GLib  # NOQA: E402
+from gi.repository import Gio  # NOQA: E402
+
+# pylint: enable=import-error, no-name-in-module
+
+NM
+GLib
+Gio
+
+
+def get_client():
+    return NM.Client.new()
+
+
+class _NmMainLoop(object):
+    def __init__(self, timeout):
+        self._mainloop = GLib.MainLoop()
+        self._cancellable = Gio.Cancellable.new()
+        self._timeout = timeout
+        self._timeout_id = None
+
+    def run(self):
+        logging.debug("NM mainloop running")
+        user_data = None
+        self._timeout_id = GLib.timeout_add(
+            int(self._timeout * 1000),
+            self._timeout_call_back,
+            user_data,
+        )
+        logging.debug("Added timeout checker")
+        self._mainloop.run()
+
+    def _timeout_call_back(self, _user_data):
+        logging.error("Timeout")
+        self.fail(LsrNetworkNmError("Timeout"))
+
+    @property
+    def cancellable(self):
+        return self._cancellable
+
+    @property
+    def is_cancelled(self):
+        if self._cancellable:
+            return self._cancellable.is_cancelled()
+        return True
+
+    def _clean_up(self):
+        logging.debug("NM mainloop cleaning up")
+        if self._timeout_id:
+            logging.debug("Removing timeout checker")
+            GLib.source_remove(self._timeout_id)
+            self._timeout_id = None
+        if self._cancellable:
+            logging.debug("Canceling all pending tasks")
+            self._cancellable.cancel()
+            self._cancellable = None
+        self._mainloop = None
+
+    def quit(self):
+        logging.debug("NM mainloop quiting")
+        self._mainloop.quit()
+        self._clean_up()
+
+    def fail(self, exception):
+        self.quit()
+        raise exception
+
+
+def get_mainloop(timeout):
+    return _NmMainLoop(timeout)

--- a/module_utils/network_lsr/nm/error.py
+++ b/module_utils/network_lsr/nm/error.py
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+class LsrNetworkNmError(Exception):
+    pass

--- a/module_utils/network_lsr/nm/provider.py
+++ b/module_utils/network_lsr/nm/provider.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+import logging
+
+# Relative import is not support by ansible 2.8 yet
+# pylint: disable=import-error, no-name-in-module
+from ansible.module_utils.network_lsr.nm.active_connection import (  # noqa:E501
+    deactivate_active_connection,
+)
+from ansible.module_utils.network_lsr.nm.client import get_client  # noqa:E501
+
+# pylint: enable=import-error, no-name-in-module
+
+
+class NetworkManagerProvider:
+    def deactivate_connection(self, connection_name, timeout, check_mode):
+        """
+        Return True if changed.
+        """
+        nm_client = get_client()
+        changed = False
+        for nm_ac in nm_client.get_active_connections():
+            nm_profile = nm_ac.get_connection()
+            if nm_profile and nm_profile.get_id() == connection_name:
+                changed |= deactivate_active_connection(nm_ac, timeout, check_mode)
+        if not changed:
+            logging.info("No active connection for {0}".format(connection_name))
+
+        return changed

--- a/tests/integration/test_ethernet.py
+++ b/tests/integration/test_ethernet.py
@@ -92,7 +92,25 @@ def _get_ip_addresses(interface):
     return ip_address.decode("UTF-8")
 
 
-def test_static_ip_with_ethernet(testnic1, provider):
+@pytest.fixture
+def network_lsr_nm_mock():
+    with mock.patch.object(
+        sys,
+        "path",
+        [parentdir, os.path.join(parentdir, "module_utils/network_lsr/nm")] + sys.path,
+    ):
+        with mock.patch.dict(
+            "sys.modules",
+            {
+                "ansible": mock.Mock(),
+                "ansible.module_utils": __import__("module_utils"),
+                "ansible.module_utils.basic": mock.Mock(),
+            },
+        ):
+            yield
+
+
+def test_static_ip_with_ethernet(testnic1, provider, network_lsr_nm_mock):
     ip_address = "192.0.2.127/24"
     connections = [
         {


### PR DESCRIPTION
When deactivating a profile in libNM, we should:

 * Check `NM.ActionConnection` existence
 * Check `NM.ActionConnection.props.state` not DEACTIVATED
 * Use signal `state-changed` of `NM.ActionConnection`.
 * Only invoke `NM.Client.deactivate_connection_async()` if not
   in DEACTIVATING state.
 * Ignore `NM.ManagerError.CONNECTIONNOTACTIVE` error.

This patch also introduced a new class `NetworkManagerProvider`
in `module_utils/network_nm_lsr`:

 * Independent from Ansible but need to use absolute import due to limitation of ansible 2.8.
 * Provide sync function wrapping async calls of libNM.
 * Use stable logging method of python.
 * Only load this module when provider is nm.

This patch also changed how logging is handling in
`Cmd_nm.run_action_down()` as initial step on isolate ansible log
mechanism from provider module.

By moving provider codes to `module_utils` folder, we can eventually
simplify the bloated `library/network_connections.py`.