### PR TITLE
github: add stale workflow

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,12 @@
+---
+# Configuration for probot-stale - https://github.com/probot/stale
+daysUntilStale: 30
+daysUntilClose: 14
+staleLabel: stale
+markComment: >
+  Thank you for your contribution! There was no activity in this pull request
+  recently. To avoid pull requests to pile up, an automated process marked this
+  pull request as stale. It will close this pull request if no further activity
+  occurs. The current policy is available at:
+  https://github.com//linux-system-roles/network/blob/main/.github/stale.yml
+only: pulls


### PR DESCRIPTION
To ensure that old/untouched pull requests do not pile up, configure the
probot stale bot to mark pull requests without activity in the last 14
days as stale and close them after 14 more days if there is no further
activity. The pull requests are marked with the stale label.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>