### PR TITLE
nm provider: Refactor the volatilize action of network connection

### DIFF
--- a/module_utils/network_lsr/nm/connection.py
+++ b/module_utils/network_lsr/nm/connection.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Handle NM.RemoteConnection
+
+import logging
+
+# Relative import is not support by ansible 2.8 yet
+# pylint: disable=import-error, no-name-in-module
+from ansible.module_utils.network_lsr.nm import client  # noqa:E501
+from ansible.module_utils.network_lsr.nm import error  # noqa:E501
+
+# pylint: enable=import-error, no-name-in-module
+
+
+def delete_remote_connection(nm_profile, timeout, check_mode):
+    if not nm_profile:
+        logging.info("NULL NM.RemoteConnection, no need to delete")
+        return False
+
+    if not check_mode:
+        main_loop = client.get_mainloop(timeout)
+        user_data = main_loop
+        nm_profile.delete_async(
+            main_loop.cancellable,
+            _nm_profile_delete_call_back,
+            user_data,
+        )
+        logging.debug(
+            "Deleting profile {id}/{uuid} with timeout {timeout}".format(
+                id=nm_profile.get_id(), uuid=nm_profile.get_uuid(), timeout=timeout
+            )
+        )
+        main_loop.run()
+    return True
+
+
+def _nm_profile_delete_call_back(nm_profile, result, user_data):
+    main_loop = user_data
+    if main_loop.is_cancelled:
+        return
+
+    try:
+        success = nm_profile.delete_finish(result)
+    except Exception as e:
+        main_loop.fail(
+            error.LsrNetworkNmError(
+                "Connection deletion aborted on {id}/{uuid}: error={error}".format(
+                    id=nm_profile.get_id(), uuid=nm_profile.get_uuid(), error=e
+                )
+            )
+        )
+    if success:
+        main_loop.quit()
+    else:
+        main_loop.fail(
+            error.LsrNetworkNmError(
+                "Connection deletion aborted on {id}/{uuid}: error=unknown".format(
+                    id=nm_profile.get_id(), uuid=nm_profile.get_uuid()
+                )
+            )
+        )
+
+
+def volatilize_remote_connection(nm_profile, timeout, check_mode):
+    if not nm_profile:
+        logging.info("NULL NM.RemoteConnection, no need to volatilize")
+        return False
+    if not check_mode:
+        main_loop = client.get_mainloop(timeout)
+        user_data = main_loop
+        nm_profile.update2(
+            None,  # settings
+            client.NM.SettingsUpdate2Flags.IN_MEMORY_ONLY
+            | client.NM.SettingsUpdate2Flags.VOLATILE,
+            None,  # args
+            main_loop.cancellable,
+            _nm_profile_volatile_update2_call_back,
+            user_data,
+        )
+        logging.debug(
+            "Volatilizing profile {id}/{uuid} with timeout {timeout}".format(
+                id=nm_profile.get_id(), uuid=nm_profile.get_uuid(), timeout=timeout
+            )
+        )
+        main_loop.run()
+    return True
+
+
+def _nm_profile_volatile_update2_call_back(nm_profile, result, user_data):
+    main_loop = user_data
+    if main_loop.is_cancelled:
+        return
+
+    try:
+        success = nm_profile.update2_finish(result)
+    except Exception as e:
+        main_loop.fail(
+            error.LsrNetworkNmError(
+                "Connection volatilize aborted on {id}/{uuid}: error={error}".format(
+                    id=nm_profile.get_id(), uuid=nm_profile.get_uuid(), error=e
+                )
+            )
+        )
+    if success:
+        main_loop.quit()
+    else:
+        main_loop.fail(
+            error.LsrNetworkNmError(
+                "Connection volatilize aborted on {id}/{uuid}: error=unknown".format(
+                    id=nm_profile.get_id(), uuid=nm_profile.get_uuid()
+                )
+            )
+        )

--- a/module_utils/network_lsr/nm/provider.py
+++ b/module_utils/network_lsr/nm/provider.py
@@ -6,6 +6,7 @@ import logging
 # pylint: disable=import-error, no-name-in-module
 from ansible.module_utils.network_lsr.nm import active_connection  # noqa:E501
 from ansible.module_utils.network_lsr.nm import client  # noqa:E501
+from ansible.module_utils.network_lsr.nm import connection  # noqa:E501
 
 # pylint: enable=import-error, no-name-in-module
 
@@ -27,3 +28,31 @@ class NetworkManagerProvider:
             logging.info("No active connection for {0}".format(connection_name))
 
         return changed
+
+    def volatilize_connection_by_uuid(self, uuid, timeout, check_mode):
+        """
+        Mark NM.RemoteConnection as volatile(delete on deactivation) via Update2,
+        if not supported, delete the profile.
+
+        Return True if changed.
+        """
+        nm_client = client.get_client()
+        changed = False
+        for nm_profile in nm_client.get_connections():
+            if nm_profile and nm_profile.get_uuid() == uuid:
+                if hasattr(nm_profile, "update2"):
+                    changed |= connection.volatilize_remote_connection(
+                        nm_profile, timeout, check_mode
+                    )
+                else:
+                    changed |= connection.delete_remote_connection(
+                        nm_profile, timeout, check_mode
+                    )
+        if not changed:
+            logging.info("No connection with UUID {0} to volatilize".format(uuid))
+
+        return changed
+
+    def get_connections(self):
+        nm_client = client.get_client()
+        return nm_client.get_connections()


### PR DESCRIPTION
Refactor the volatilize action of nm provider:
 * Move code to `module_utils/network_lsr/nm`
 * The `module_utils/network_lsr/nm` only delete profile by given UUID
   instead of guess. The `library/network_connections.py` is responsible
   on choosing UUID.