### PR TITLE
test 802.1x: Install openssl as test dependency

### DIFF
--- a/tests/tasks/test_802.1x_capath.yml
+++ b/tests/tasks/test_802.1x_capath.yml
@@ -28,6 +28,10 @@
     src: "cacert.pem"
     dest: "/etc/pki/tls/my_ca_certs/cacert.pem"
     mode: 0644
+- name: Install openssl (test dependency)
+  package:
+    name: openssl
+    state: present
 - name: Hash cacert
   command: openssl x509 -hash -noout
     -in /etc/pki/tls/my_ca_certs/cacert.pem


### PR DESCRIPTION
The Fedora 33 cloud image does not have openssl installed by default,
install openssl before using its cli tool.