### PR TITLE
test_unit.yml, tests_integration_pytest.yml - support the collection converted format.

### DIFF
--- a/tests/integration/test_ethernet.py
+++ b/tests/integration/test_ethernet.py
@@ -7,12 +7,20 @@ import pytest
 import subprocess
 import sys
 
+from importlib import import_module
+
 try:
     from unittest import mock
 except ImportError:
     import mock
 
-parentdir = os.path.normpath(os.path.join(os.path.dirname(__file__), "../../"))
+_is_role = os.path.exists(
+    os.path.join(os.path.dirname(__file__), "../roles/linux-system-roles.network")
+)
+if _is_role:
+    parentdir = os.path.normpath(os.path.join(os.path.dirname(__file__), "../../"))
+else:  # collection
+    parentdir = os.path.normpath(os.path.join(os.path.dirname(__file__), "../"))
 with mock.patch.object(
     sys,
     "path",
@@ -26,7 +34,10 @@ with mock.patch.object(
             "ansible.module_utils.basic": mock.Mock(),
         },
     ):
-        import library.network_connections as nc
+        if _is_role:
+            nc = import_module("library.network_connections")
+        else:
+            nc = import_module("modules.network_connections")
 
 
 class PytestRunEnvironment(nc.RunEnvironment):

--- a/tests/playbooks/integration_pytest_python3.yml
+++ b/tests/playbooks/integration_pytest_python3.yml
@@ -42,10 +42,15 @@
         path: "{{ rundir }}"
         recurse: true
 
-    - name: Determine legacy role format or collection format
-      local_action:
-        stat path="{{ playbook_dir }}/roles/linux-system-roles.network"
-      register: _role
+    - name: Get collection paths
+      set_fact:
+        _collection_paths: |
+          {{
+             (lookup("env","ANSIBLE_COLLECTIONS_PATH").split(":") +
+             lookup("env","ANSIBLE_COLLECTIONS_PATHS").split(":") +
+             lookup("env","COLLECTIONS_PATHS").split(":")) |
+             select | list
+          }}
 
     - name: Legacy role format
       block:
@@ -80,10 +85,33 @@
                  -C {{ git_top_directory.stdout }} .'
           delegate_to: localhost
 
-      when: _role.stat.exists
+      when: "{{ _collection_paths | d([]) | length == 0 }}"
 
     - name: Collection role format
       block:
+
+        - name: Get the distribution of the control host
+          shell: grep "^ID=" /etc/os-release
+          register: _my_id
+          delegate_to: localhost
+
+        - name: Stat network_lsr with the collections module_utils path
+          vars:
+            - _network_lsr_path: "\
+              {{ item }}/ansible_collections/\
+              {{ _my_id.stdout.split('=')[1] }}/\
+              system_roles/plugins/module_utils/network_lsr"
+          local_action:
+            stat path="{{ _network_lsr_path }}"
+          register: _network_lsr
+          loop: "{{ _collection_paths | d([]) }}"
+
+        - name: Check if network_lsr exist or not
+          set_fact:
+            _is_collection: "{{ _network_lsr.results |
+                                selectattr('stat', 'defined') |
+                                selectattr('stat.exists', '==', True) | list }}"
+          failed_when: _is_collection | d([]) | length == 0
 
         - name: Create Tar file
           shell: 'tar -cvf {{ playbook_dir }}/testrepo.tar
@@ -92,7 +120,7 @@
                  --transform "s,^\.,tests," .'
           delegate_to: localhost
 
-      when: not _role.stat.exists
+      when: _collection_paths | d([])
 
     - name: Copy testrepo.tar to the remote system
       copy:

--- a/tests/playbooks/integration_pytest_python3.yml
+++ b/tests/playbooks/integration_pytest_python3.yml
@@ -42,37 +42,65 @@
         path: "{{ rundir }}"
         recurse: true
 
-    - command: git rev-parse --show-toplevel
-      register: git_top_directory
-      delegate_to: localhost
+    - name: Determine legacy role format or collection format
+      local_action:
+        stat path="{{ playbook_dir }}/roles/linux-system-roles.network"
+      register: _role
 
-    - debug:
-        var: git_top_directory
+    - name: Legacy role format
+      block:
+        - command: git rev-parse --show-toplevel
+          register: git_top_directory
+          delegate_to: localhost
 
-    - synchronize:
-        src: "{{ git_top_directory.stdout }}/"
-        dest: "{{ rundir }}/"
-        recursive: yes
-        delete: yes
-        rsync_opts:
-          - "--exclude=.pyc"
-          - "--exclude=__pycache__"
-      when: False
+        - debug:
+            var: git_top_directory
 
-    # TODO: using tar and copying the file is a workaround for the synchronize
-    # module that does not work in test-harness. Related issue:
-    # https://github.com/linux-system-roles/test-harness/issues/102
-    #
-    - name: Create Tar file
-      shell: 'tar -cvf {{ git_top_directory.stdout }}/testrepo.tar
-             --exclude "*.pyc" --exclude "__pycache__" --exclude testrepo.tar
-             -C {{ git_top_directory.stdout }} .'
-      delegate_to: localhost
+        - synchronize:
+            src: "{{ git_top_directory.stdout }}/"
+            dest: "{{ rundir }}/"
+            recursive: yes
+            delete: yes
+            rsync_opts:
+              - "--exclude=.pyc"
+              - "--exclude=__pycache__"
+          when: false
+
+        # TODO: using tar and copying the file is a workaround for
+        # the synchronize module that does not work in test-harness.
+        # Related issue:
+        # https://github.com/linux-system-roles/test-harness/issues/102
+        #
+
+        - name: Create Tar file
+          shell: 'tar -cvf {{ playbook_dir }}/testrepo.tar
+                 --exclude "*.pyc" --exclude "__pycache__"
+                 --exclude testrepo.tar --exclude ".git"
+                 --exclude ".tox"
+                 -C {{ git_top_directory.stdout }} .'
+          delegate_to: localhost
+
+      when: _role.stat.exists
+
+    - name: Collection role format
+      block:
+
+        - name: Create Tar file
+          shell: 'tar -cvf {{ playbook_dir }}/testrepo.tar
+                 --exclude "*.pyc" --exclude "__pycache__"
+                 --exclude testrepo.tar -C {{ playbook_dir }}/..
+                 --transform "s,^\.,tests," .'
+          delegate_to: localhost
+
+      when: not _role.stat.exists
 
     - name: Copy testrepo.tar to the remote system
       copy:
-        src: "{{ git_top_directory.stdout }}/testrepo.tar"
+        src: "{{ playbook_dir }}/testrepo.tar"
         dest: "{{ rundir }}"
+
+    - name: Remove testrepo.tar
+      local_action: file path="{{ playbook_dir }}/testrepo.tar" state=absent
 
     - name: Untar testrepo.tar
       command: tar xf testrepo.tar

--- a/tests/tests_unit.yml
+++ b/tests/tests_unit.yml
@@ -29,15 +29,24 @@
 - hosts: all
   name: execute python unit tests
   tasks:
-    - name: Copy python modules
-      copy:
-        src: "{{ item }}"
-        dest: /tmp/test-unit-1/
-        local_follow: false
+    - name: Check python modules existence
+      local_action: stat path="{{ item }}"
+      register: _present_modules
       loop:
         - ../library/network_connections.py
         - unit/test_network_connections.py
         - ../module_utils/network_lsr
+        - module_utils/network_lsr
+        - modules/network_connections.py
+      ignore_errors: true
+
+    - name: Copy python modules
+      copy:
+        src: "{{ item.stat.path }}"
+        dest: /tmp/test-unit-1/
+        local_follow: false
+      when: item.stat.exists
+      loop: "{{ _present_modules.results }}"
 
     - name: Create helpers directory
       file:

--- a/tests/unit/test_network_connections.py
+++ b/tests/unit/test_network_connections.py
@@ -11,8 +11,14 @@ import unittest
 import copy
 
 TESTS_BASEDIR = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(1, os.path.join(TESTS_BASEDIR, "../..", "library"))
-sys.path.insert(1, os.path.join(TESTS_BASEDIR, "../..", "module_utils"))
+for candidate in (
+    os.path.join(TESTS_BASEDIR, "..", "modules"),
+    os.path.join(TESTS_BASEDIR, "../..", "library"),
+    os.path.join(TESTS_BASEDIR, "..", "module_utils"),
+    os.path.join(TESTS_BASEDIR, "../..", "module_utils"),
+):
+    if os.path.isdir(candidate):
+        sys.path.insert(1, candidate)
 
 try:
     from unittest import mock

--- a/tests/unit/test_nm_provider.py
+++ b/tests/unit/test_nm_provider.py
@@ -6,8 +6,14 @@ import os
 import sys
 
 TESTS_BASEDIR = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(1, os.path.join(TESTS_BASEDIR, "../..", "library"))
-sys.path.insert(1, os.path.join(TESTS_BASEDIR, "../..", "module_utils"))
+for candidate in (
+    os.path.join(TESTS_BASEDIR, "..", "modules"),
+    os.path.join(TESTS_BASEDIR, "../..", "library"),
+    os.path.join(TESTS_BASEDIR, "..", "module_utils"),
+    os.path.join(TESTS_BASEDIR, "../..", "module_utils"),
+):
+    if os.path.exists(candidate):
+        sys.path.insert(1, candidate)
 
 try:
     from unittest import mock


### PR DESCRIPTION
tests_integration_pytest.yml

    To run the pytest on the target hosts via CI tests, integration_pytest_
    python3.yml copies entire network role to the target. To get the top
    directory, it uses a git command line. But the method cannot be used
    in the collection converted format since the converted roles and tests
    are not located in the git-cloned directory.
    
    In the collection converted format, the network tests directory has the
    copy of modules and module_utils. Taking advantage of the self-contained
    tests, we can just copy the files and directories in the tests and run
    test_integration_pytest successfully in the target host.

tests_unit.yml

    The unit test depends on the relative paths to library and module_utils,
    which are no longer available from the tests dir. (The tests directory
    in the collections CI is independent from the collections path.) To
    workaround it, the library and module_utils are copied to the tests
    directory and let the unit test additionally refer them.