### PR TITLE
test: Fix profile assertion on Fedora 33

### DIFF
--- a/tests/integration/test_ethernet.py
+++ b/tests/integration/test_ethernet.py
@@ -122,4 +122,7 @@ def test_static_ip_with_ethernet(testnic1, provider, network_lsr_nm_mock):
     ]
     _configure_network(connections, provider)
     assert ip_address in _get_ip_addresses(testnic1)
-    assert os.path.exists("/etc/sysconfig/network-scripts/ifcfg-" + testnic1)
+    if provider == "initscripts":
+        assert os.path.exists("/etc/sysconfig/network-scripts/ifcfg-" + testnic1)
+    else:
+        subprocess.check_call(["nmcli", "connection", "show", testnic1])

--- a/tests/tasks/assert_profile_absent.yml
+++ b/tests/tasks/assert_profile_absent.yml
@@ -3,5 +3,5 @@
 - include: get_profile_stat.yml
 - name: "assert that profile '{{ profile }}' is absent"
   assert:
-    that: not profile_stat.stat.exists
-    msg: "profile {{ profile_path }} does exist"
+    that: not lsr_net_profile_exists
+    msg: "profile {{ profile }} does exist"

--- a/tests/tasks/assert_profile_present.yml
+++ b/tests/tasks/assert_profile_present.yml
@@ -3,5 +3,5 @@
 - include: get_profile_stat.yml
 - name: "assert that profile '{{ profile }}' is present"
   assert:
-    that: profile_stat.stat.exists
-    msg: "profile {{ profile_path }} does not exist"
+    that: lsr_net_profile_exists
+    msg: "profile {{ profile }} does not exist"

--- a/tests/tasks/get_profile_stat.yml
+++ b/tests/tasks/get_profile_stat.yml
@@ -1,26 +1,24 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- name: "Get stat for network-scripts"
-  stat:
-    get_attributes: false
-    get_checksum: false
-    get_mime: false
-    path: "/etc/sysconfig/network-scripts"
-  register: network_scripts_stat
-- name: Set profile path (network-scripts)
-  set_fact:
-    profile_path: /etc/sysconfig/network-scripts/ifcfg-{{ profile }}
-  when:
-    - network_scripts_stat.stat.exists
-- name: Set profile path (NetworkManager system-connections)
-  set_fact:
-    profile_path: /etc/NetworkManager/system-connections/{{ profile }}
-  when:
-    - not network_scripts_stat.stat.exists
+- set_fact: lsr_net_profile_exists=false
+
 - name: stat profile file
   stat:
     get_attributes: false
     get_checksum: false
     get_mime: false
-    path: "{{ profile_path }}"
+    path: /etc/sysconfig/network-scripts/ifcfg-{{ profile }}
   register: profile_stat
+
+- set_fact: lsr_net_profile_exists=true
+  when: profile_stat.stat.exists
+
+# When certain profile is marked as absent but still up, the `nmcli connection`
+# still show it with FILENAME starting with /run. Only consider profile exists
+# when its FILENAME is in /etc folder
+- shell: nmcli -f NAME,FILENAME connection show |grep {{ profile }} | grep /etc
+  register: nm_profile_exists
+  ignore_errors: yes
+
+- set_fact: lsr_net_profile_exists=true
+  when: nm_profile_exists.rc == 0


### PR DESCRIPTION
The NetworkManager in Fedora 33 does not use ifcfg-rh plugin by default,
the CI will fail on Fedora 33 with:

```
TASK [assert that profile 'bond0' is present] **********************************
task path: /tmp/tmpaz9m374e/tests/playbooks/tasks/assert_profile_present.yml:4
fatal: [/cache/fedora-33.qcow2]: FAILED! => {
    "assertion": "profile_stat.stat.exists",
    "changed": false,
    "evaluated_to": false,
    "msg": "profile /etc/sysconfig/network-scripts/ifcfg-bond0 does not exist"
}
```

Previously, we are checking the existence of
`/etc/sysconfig/network-scripts/` to determine whether ifcfg-rh plugin
is enabled. This is incorrect on Fedora 33.

The fix is checking the FILENAME[1] used for storing the NetworkManager
connection, the profile is considered as exists when it exists and does
not contains `/run`.

Since we cannot tell which provider we are using, we just check both
initscripts files and NetworkManager connections.

[1]: nmcli -f NAME,FILENAME connection show
