### PR TITLE
Fix python line length problem

### DIFF
--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -822,7 +822,9 @@ class NMUtil:
         elif connection["type"] == "team":
             s_con.set_property(NM.SETTING_CONNECTION_TYPE, NM.SETTING_TEAM_SETTING_NAME)
         elif connection["type"] == "dummy":
-            s_con.set_property(NM.SETTING_CONNECTION_TYPE, NM.SETTING_DUMMY_SETTING_NAME)
+            s_con.set_property(
+                NM.SETTING_CONNECTION_TYPE, NM.SETTING_DUMMY_SETTING_NAME
+            )
         elif connection["type"] == "vlan":
             s_con.set_property(NM.SETTING_CONNECTION_TYPE, NM.SETTING_VLAN_SETTING_NAME)
             s_vlan = self.connection_ensure_setting(con, NM.SettingVlan)


### PR DESCRIPTION
The line was too long, and needed to be wrapped in a way that was
compatible with python black formatting.