### PR TITLE
fix collection lookup problem

### DIFF
--- a/tests/tasks/get_modules_and_utils_paths.yml
+++ b/tests/tasks/get_modules_and_utils_paths.yml
@@ -50,6 +50,7 @@
       fi
     done
     for dir in {{ collection_paths | join(" ") }}; do
+      if [ ! -d "$dir" ]; then continue; fi
       cd "$dir"
       for subdir in ansible_collections/*/*/plugins/modules; do
         if [ -f "$subdir/network_connections.py" ]; then
@@ -75,6 +76,7 @@
       fi
     done
     for dir in {{ collection_paths | join(" ") }}; do
+      if [ ! -d "$dir" ]; then continue; fi
       cd "$dir"
       for subdir in ansible_collections/*/*/plugins/module_utils; do
         if [ -d "$subdir/network_lsr" ]; then


### PR DESCRIPTION
This fixes the following error:
```
/bin/sh: line 9: cd: /root/.ansible/collections: No such file or directory
```
The fix is to ensure the directory exists before attempting
to `cd` to the directory.