### PR TITLE
use tox-lsr 2.2.1

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,7 +3,7 @@ name: tox
 on:  # yamllint disable-line rule:truthy
   - pull_request
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.2.0"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.2.1"
   LSR_ANSIBLES: 'ansible==2.8.* ansible==2.9.*'
   LSR_MSCENARIOS: default
   # LSR_EXTRA_PACKAGES: "libdbus-1-dev libgirepository1.0-dev python3-dev"


### PR DESCRIPTION
Upgrade to tox-lsr 2.2.1 to pick up fix for lock down the
version of ansible to ansible==2.10.* in tox-lsr.