### PR TITLE
Cleaning up ansible-lint errors except '106', '303' and '403'

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,12 +1,5 @@
 ---
 skip_list:
 - '106'  # Role name does not match ^[a-z][a-z0-9_]+$ pattern
-- '206'  # Variables should have spaces before and after: {{ var_name }}
-- '208'  # File permissions unset or incorrect
-- '301'  # Commands should not change things if nothing needs doing
 - '303'  # Using command rather than module
-- '305'  # Use shell only when shell functionality is required
 - '403'  # Package installs should not use latest
-- '502'  # All tasks should be named
-- '601'  # Don't compare to literal True/False
-- '602'  # Don't compare to empty string

--- a/tests/get_coverage.yml
+++ b/tests/get_coverage.yml
@@ -26,11 +26,12 @@
           # yamllint disable-line rule:line-length
           Getting coverage for '{{ coverage_module }}' with '{{ test_playbook }}'
 
-    # combine data in case old data is left there
-    - command: "{{ coverage }} combine"
+    - name: combine data in case old data is left there
+      command: "{{ coverage }} combine"
       environment:
         COVERAGE_FILE: "{{ coverage_file }}"
       ignore_errors: yes
+      changed_when: false
 
     - name: remove old data
       file:
@@ -54,6 +55,7 @@
       copy:
         content: "[run]\ndisable_warnings = no-data-collected\n"
         dest: .coveragerc
+        mode: "0644"
 
     - name: install latest pip
       pip:
@@ -69,14 +71,17 @@
 - name: Gather coverage data
   hosts: all
   tasks:
-    - shell: "{{ coverage }} combine .coverage.*"
+    - name: gather coverage data
+      shell: "{{ coverage }} combine .coverage.*"
       environment:
         COVERAGE_FILE: "{{ coverage_file }}"
+      changed_when: false
 
 - name: Get coverage data
   hosts: all
   tasks:
-    - fetch:
+    - name: "Fetch {{ coverage_file }}"
+      fetch:
         src: "{{ coverage_file }}"
         dest: "{{ destdir }}"
         flat: no

--- a/tests/playbooks/integration_pytest_python3.yml
+++ b/tests/playbooks/integration_pytest_python3.yml
@@ -16,6 +16,7 @@
 
     - name: Install Pytest
       command: "pip3 install pytest"
+      changed_when: false
 
 
 # Import needed in order to install initscripts dependencies on the remote
@@ -77,15 +78,18 @@
           copy:
             src: "{{ temptar.path }}"
             dest: "{{ _rundir.path }}"
+            mode: preserve
 
         - name: Untar testrepo.tar
           command: tar xf {{ temptar.path | basename }}
           args:
             chdir: "{{ _rundir.path }}"
 
-        - file:
+        - name: "Create {{ _rundir.path }}/ansible"
+          file:
             state: directory
             path: "{{ _rundir.path }}/ansible"
+            mode: "0755"
 
         - name: Move module_utils to ansible directory
           shell: |
@@ -101,7 +105,8 @@
               fi
             done
 
-        - set_fact:
+        - name: Set _lsr_python_path
+          set_fact:
             _lsr_python_path: "{{
                   _rundir.path ~ '/' ~
                   modules_parent_and_dir.stdout_lines[1] ~ ':' ~ _rundir.path
@@ -109,7 +114,8 @@
 
         - debug:
             msg: path {{ _lsr_python_path }}
-        - command: ls -alrtFR {{ _rundir.path }}
+        - name: "ls -alrtFR {{ _rundir.path }}"
+          command: ls -alrtFR {{ _rundir.path }}
 
         - block:
             - name: Run pytest with nm

--- a/tests/playbooks/tests_checkpoint_cleanup.yml
+++ b/tests/playbooks/tests_checkpoint_cleanup.yml
@@ -19,7 +19,8 @@
   tasks:
     - block:
         # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1832897
-        - package:
+        - name: install dbus-tools
+          package:
             name: dbus-tools
             state: present
         # create test profile
@@ -37,7 +38,8 @@
         - include_tasks: tasks/assert_device_present.yml
         - include_tasks: tasks/assert_profile_present.yml
         # Use internal module directly for speedup
-        - network_connections:
+        - name: use network_connections
+          network_connections:
             provider: nm
             connections:
               - name: "{{ interface }}"
@@ -48,13 +50,15 @@
                   auto6: false
           ignore_errors: true
           register: error_trigger
-        - assert:
+        - name: assert that the module call did not fail
+          assert:
             fail_msg: The module call did not fail. Therefore the test
               condition was not triggered. This test needs to be adjusted or
               dropped.
             that: error_trigger.failed
         # yamllint disable-line rule:line-length
-        - command: busctl --system tree --list org.freedesktop.NetworkManager
+        - name: get NM dbus objects
+          command: busctl --system tree --list org.freedesktop.NetworkManager
           register: nm_dbus_objects
         - debug:
             var: nm_dbus_objects

--- a/tests/playbooks/tests_eth_dns_support.yml
+++ b/tests/playbooks/tests_eth_dns_support.yml
@@ -70,6 +70,7 @@
         nmcli connection show {{ interface }} | grep ipv4.dns
       register: ipv4_dns
       ignore_errors: yes
+      changed_when: false
 
     - name: "Assert that DNS addresses are configured correctly"
       assert:

--- a/tests/playbooks/tests_ethtool_coalesce.yml
+++ b/tests/playbooks/tests_ethtool_coalesce.yml
@@ -43,7 +43,7 @@
           register: no_coalesce
         - name: "ASSERT: The profile does not contain coalescing options"
           assert:
-            that: no_coalesce.stdout == ""
+            that: no_coalesce.stdout | length == 0
         - name: >-
             TEST: I can set rx-frames.
           debug:
@@ -85,7 +85,7 @@
           register: profile
         - name: "ASSERT: The profile does reset coalescing options"
           assert:
-            that: no_coalesce.stdout == ""
+            that: no_coalesce.stdout | length == 0
       always:
         - block:
             - import_role:

--- a/tests/playbooks/tests_ethtool_features.yml
+++ b/tests/playbooks/tests_ethtool_features.yml
@@ -157,7 +157,7 @@
               debug:
                 var: __network_connections_result
             - assert:
-                that: "{{ __network_connections_result.failed == true }}"
+                that: __network_connections_result.failed
 
 
         - name: "TEST: I can reset features to their original value."

--- a/tests/playbooks/tests_ipv6_disabled.yml
+++ b/tests/playbooks/tests_ipv6_disabled.yml
@@ -35,6 +35,7 @@
         nmcli connection show {{ interface }} | grep ipv6.method
       register: ipv6_method
       ignore_errors: yes
+      changed_when: false
 
     - name: "Assert that ipv6.method disabled is configured correctly"
       assert:

--- a/tests/playbooks/tests_reapply.yml
+++ b/tests/playbooks/tests_reapply.yml
@@ -32,7 +32,8 @@
         - include_tasks: tasks/assert_device_present.yml
         - include_tasks: tasks/assert_profile_present.yml
         # Use internal module to get output
-        - network_connections:
+        - name: Get network_connections output
+          network_connections:
             provider: nm
             connections:
               - name: "{{ interface }}"

--- a/tests/tasks/cleanup_802_1x_server.yml
+++ b/tests/tasks/cleanup_802_1x_server.yml
@@ -6,9 +6,11 @@
     ip link delete veth1-br
     ip link delete veth2-br
     ip link delete br1
+  changed_when: false
 
 - name: Kill hostapd process
-  shell: pkill hostapd
+  command: pkill hostapd
+  changed_when: false
 - name: Remove certs and config
   file:
     state: absent

--- a/tests/tasks/cleanup_mock_wifi.yml
+++ b/tests/tasks/cleanup_mock_wifi.yml
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
 - name: Unload mac80211_hwsim module
-  shell: modprobe -r mac80211_hwsim
+  command: modprobe -r mac80211_hwsim
+  changed_when: false
 
 - name: Kill hostapd process
-  shell: pkill hostapd
+  command: pkill hostapd
+  changed_when: false

--- a/tests/tasks/create_test_interfaces_with_dhcp.yml
+++ b/tests/tasks/create_test_interfaces_with_dhcp.yml
@@ -16,10 +16,10 @@
     udevadm settle --timeout=5
 
     # Setuptwo devices with IPv4/IPv6 auto support
-    ip link add {{dhcp_interface1}} type veth peer name {{dhcp_interface1}}p
-    ip link set {{dhcp_interface1}}p up
-    ip link add {{dhcp_interface2}} type veth peer name {{dhcp_interface2}}p
-    ip link set {{dhcp_interface2}}p up
+    ip link add {{ dhcp_interface1 }} type veth peer name {{ dhcp_interface1 }}p
+    ip link set {{ dhcp_interface1 }}p up
+    ip link add {{ dhcp_interface2 }} type veth peer name {{ dhcp_interface2 }}p
+    ip link set {{ dhcp_interface2 }}p up
 
     # Create the 'testbr' - providing both 10.x ipv4 and 2620:52:0 ipv6 dhcp
     ip link add name testbr type bridge forward_delay 0
@@ -36,8 +36,8 @@
         iptables -I INPUT -i testbr -p udp --dport 67:68 --sport 67:68 -j ACCEPT
 
         # Add {{dhcp_interface1}}, {{dhcp_interface2}} peers into the testbr
-        brctl addif testbr {{dhcp_interface1}}p
-        brctl addif testbr {{dhcp_interface2}}p
+        brctl addif testbr {{ dhcp_interface1 }}p
+        brctl addif testbr {{ dhcp_interface2 }}p
 
         # in RHEL6 /run is not present
         mkdir -p /run
@@ -61,8 +61,8 @@
         service radvd restart
 
     else
-        ip link set {{dhcp_interface1}}p master testbr
-        ip link set {{dhcp_interface2}}p master testbr
+        ip link set {{ dhcp_interface1 }}p master testbr
+        ip link set {{ dhcp_interface2 }}p master testbr
         # Run joint DHCP4/DHCP6 server with RA enabled in veth namespace
         dnsmasq \
             --pid-file=/run/dhcp_testbr.pid \
@@ -71,3 +71,4 @@
             --dhcp-range=2001:DB8::10,2001:DB8::1FF,slaac,64,240 \
             --enable-ra --interface=testbr --bind-interfaces
     fi
+  changed_when: false

--- a/tests/tasks/el_repo_setup.yml
+++ b/tests/tasks/el_repo_setup.yml
@@ -20,6 +20,7 @@
       baseurl=https://vault.centos.org/6.10/extras/$basearch/
       gpgcheck=1
       gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+    mode: "0644"
   when:
     - ansible_distribution == 'CentOS'
     - ansible_distribution_major_version == '6'

--- a/tests/tasks/enable_epel.yml
+++ b/tests/tasks/enable_epel.yml
@@ -19,6 +19,7 @@
       baseurl=https://archives.fedoraproject.org/pub/archive/epel/6/$basearch
       enabled=1
       gpgcheck=0
+    mode: "0644"
   when:
     - ansible_distribution in ['RedHat', 'CentOS']
     - ansible_distribution_major_version == '6'

--- a/tests/tasks/get_current_interfaces.yml
+++ b/tests/tasks/get_current_interfaces.yml
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- command: ls -1
+- name: Gather current interface info
+  command: ls -1
   args:
     chdir: /sys/class/net
   register: _current_interfaces
-- set_fact:
+  changed_when: false
+- name: Set current_interfaces
+  set_fact:
     current_interfaces: "{{ _current_interfaces.stdout_lines }}"

--- a/tests/tasks/get_modules_and_utils_paths.yml
+++ b/tests/tasks/get_modules_and_utils_paths.yml
@@ -64,6 +64,7 @@
     exit 1
   delegate_to: localhost
   register: modules_parent_and_dir
+  changed_when: false
 
 - name: find parent directory and path of module_utils
   shell: |
@@ -90,3 +91,4 @@
     exit 1
   delegate_to: localhost
   register: module_utils_parent_and_dir
+  changed_when: false

--- a/tests/tasks/get_profile_stat.yml
+++ b/tests/tasks/get_profile_stat.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- set_fact: lsr_net_profile_exists=false
+- name: Initialize NM profile exist flag
+  set_fact: lsr_net_profile_exists=false
 
 - name: stat profile file
   stat:
@@ -10,15 +11,19 @@
     path: /etc/sysconfig/network-scripts/ifcfg-{{ profile }}
   register: profile_stat
 
-- set_fact: lsr_net_profile_exists=true
+- name: Set NM profile exist flag based on the profile files
+  set_fact: lsr_net_profile_exists=true
   when: profile_stat.stat.exists
 
 # When certain profile is marked as absent but still up, the `nmcli connection`
 # still show it with FILENAME starting with /run. Only consider profile exists
 # when its FILENAME is in /etc folder
-- shell: nmcli -f NAME,FILENAME connection show |grep {{ profile }} | grep /etc
+- name: Get NM profile info
+  shell: nmcli -f NAME,FILENAME connection show |grep {{ profile }} | grep /etc
   register: nm_profile_exists
   ignore_errors: yes
+  changed_when: false
 
-- set_fact: lsr_net_profile_exists=true
+- name: Set NM profile exist flag based on the nmcli output
+  set_fact: lsr_net_profile_exists=true
   when: nm_profile_exists.rc == 0

--- a/tests/tasks/manage_test_interface.yml
+++ b/tests/tasks/manage_test_interface.yml
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- fail:
+- name: Ensure state in ["present", "absent"]
+  fail:
     msg: "state needs to be present or absent, not '{{ state }}'"
   when: state not in ["present", "absent"]
 
-- fail:
+- name: Ensure type in ["dummy", "tap", "veth"]
+  fail:
     msg: "type needs to be dummy, tap or veth, not '{{ type }}'"
   when: type not in ["dummy", "tap", "veth"]
 
@@ -25,7 +27,7 @@
   when: "type == 'veth' and state == 'present' and
          interface not in current_interfaces"
 - name: Set up veth as managed by NetworkManager
-  shell: nmcli d set {{ interface }} managed true
+  command: nmcli d set {{ interface }} managed true
   # The varible for `network_provider` is not exists yet,
   # just ignore error for initscripts
   ignore_errors: yes

--- a/tests/tasks/remove_test_interfaces_with_dhcp.yml
+++ b/tests/tasks/remove_test_interfaces_with_dhcp.yml
@@ -2,14 +2,15 @@
 ---
 - name: Remove test interfaces
   shell: |
-    ip link delete {{dhcp_interface1}}
-    ip link delete {{dhcp_interface2}}
+    ip link delete {{ dhcp_interface1 }}
+    ip link delete {{ dhcp_interface2 }}
     ip link delete testbr
 
     # Remove udev rule for NM to see veth devices starting with test*.....
     rm -rf /etc/udev/rules.d/88-veth.rules
     udevadm control --reload-rules
     udevadm settle --timeout=5
+  changed_when: false
 
 
 - name: Stop dnsmasq/radvd services
@@ -23,3 +24,4 @@
         iptables -D INPUT -i testbr -p udp --dport 67:68 --sport 67:68 -j ACCEPT
 
     fi
+  changed_when: false

--- a/tests/tasks/run_test.yml
+++ b/tests/tasks/run_test.yml
@@ -56,7 +56,8 @@
         var: "{{ item }}"
       loop: "{{ lsr_fail_debug | default([]) }}"
 
-    - fail:
+    - name: Issue failed message
+      fail:
         msg: "!!!!! Failure in test '{{ lsr_description }}' !!!!!"
 
   always:

--- a/tests/tasks/setup_802_1x_server.yml
+++ b/tests/tasks/setup_802_1x_server.yml
@@ -9,10 +9,12 @@
   file:
     state: directory
     path: /etc/pki/tls/hostapd_test
+    mode: "0755"
 - name: Copy server certificates
   copy:
     src: "{{ item }}"
     dest: "/etc/pki/tls/hostapd_test/{{ item }}"
+    mode: "0644"
   with_items:
     - server.key
     - dh.pem
@@ -44,6 +46,7 @@
 
     # Enable forwarding of EAP 802.1x messages through software bridge "br1".
     echo 8 > /sys/class/net/br1/bridge/group_fwd_mask
+  changed_when: false
 
 - name: Create hostapd config
   copy:
@@ -64,12 +67,15 @@
       logger_syslog=-1
       logger_syslog_level=0
     dest: /etc/hostapd/wired.conf
+    mode: "0644"
 
 - name: Create eap_user_file config
   copy:
     content: |
       * TLS
     dest: /etc/hostapd/hostapd.eap_user
+    mode: "0644"
 
 - name: Run hostapd in namespace
   shell: ip netns exec ns1 hostapd -B /etc/hostapd/wired.conf && sleep 5
+  changed_when: false

--- a/tests/tasks/setup_mock_wifi.yml
+++ b/tests/tasks/setup_mock_wifi.yml
@@ -17,6 +17,7 @@
   copy:
     src: "{{ item }}"
     dest: "/etc/pki/tls/{{ item }}"
+    mode: "0644"
   with_items:
     - server.key
     - dh.pem
@@ -52,15 +53,18 @@
       logger_syslog=-1
       logger_syslog_level=0
     dest: /etc/hostapd/wireless.conf
+    mode: "0644"
 
 - name: Create eap_user_file config
   copy:
     content: |
       * TLS
     dest: /etc/hostapd/hostapd.eap_user
+    mode: "0644"
 
 - name: Load mac80211_hwsim kernel module to mock a wifi network
   shell: modprobe mac80211_hwsim && sleep 5
+  changed_when: false
 
 - name: Restart NetworkManager and wpa_supplicant
   service:
@@ -77,6 +81,8 @@
     nmcli device set wlan1 managed off
     ip add add 203.0.113.1/24 dev wlan1
     sleep 5
+  changed_when: false
 
 - name: Start hostapd
   shell: hostapd -B /etc/hostapd/wireless.conf && sleep 5
+  changed_when: false

--- a/tests/tasks/test_802.1x_capath.yml
+++ b/tests/tasks/test_802.1x_capath.yml
@@ -3,7 +3,8 @@
     TEST: 802.1x profile with unencrypted private key and ca_path
   debug:
     msg: "##################################################"
-- set_fact:
+- name: Set __NM_capath_ignored_NVRs
+  set_fact:
     # Fixed versions/NVRs:
     # 1.25.2
     # NetworkManager-1.24.2-1.fc33
@@ -36,6 +37,7 @@
   command: openssl x509 -hash -noout
     -in /etc/pki/tls/my_ca_certs/cacert.pem
   register: cacert_hash
+  changed_when: false
 - name: Add symlink for cacert
   file:
     state: link
@@ -46,6 +48,7 @@
     cmd: rpm -qa NetworkManager
     warn: false
   register: __network_NM_NVR
+  changed_when: false
 - block:
     - import_role:
         name: linux-system-roles.network
@@ -81,6 +84,7 @@
         - ansible_failed_task
         - __network_NM_NVR.stdout
         - __NM_capath_ignored_NVRs
+      changed_when: false
 
     - name: Assert role behavior
       vars:

--- a/tests/tests_unit.yml
+++ b/tests/tests_unit.yml
@@ -55,15 +55,18 @@
           copy:
             src: "{{ temptar.path }}"
             dest: "{{ _rundir.path }}"
+            mode: preserve
 
         - name: Untar testrepo.tar
           command: tar -xvf {{ temptar.path | basename }}
           args:
             chdir: "{{ _rundir.path }}"
 
-        - file:
+        - name: Create {{ _rundir.path }}/ansible/module_utils
+          file:
             state: directory
             path: "{{ item }}"
+            mode: "0755"
           loop:
             - "{{ _rundir.path }}/ansible"
             - "{{ _rundir.path }}/ansible/module_utils"
@@ -86,8 +89,10 @@
           copy:
             src: unit/test_network_connections.py
             dest: "{{ _rundir.path }}"
+            mode: preserve
 
-        - set_fact:
+        - name: Set _lsr_python_path
+          set_fact:
             _lsr_python_path: "{{
               _rundir.path ~ '/' ~
               modules_parent_and_dir.stdout_lines[1] ~ ':' ~
@@ -98,7 +103,8 @@
               _rundir.path
             }}"
 
-        - command: ls -alrtFR {{ _rundir.path }}
+        - name: "ls -alrtFR {{ _rundir.path }}"
+          command: ls -alrtFR {{ _rundir.path }}
         - debug:
             msg: path {{ _lsr_python_path }}
 


### PR DESCRIPTION
That is the following errors are fixed.
'206'  # Variables should have spaces before and after: {{ var_name }}
'208'  # File permissions unset or incorrect
'301'  # Commands should not change things if nothing needs doing
'305'  # Use shell only when shell functionality is required
'502'  # All tasks should be named
'601'  # Don't compare to literal True/False
'602'  # Don't compare to empty string

RHELPLAN-73471

Signed-off-by: Noriko Hosoi <nhosoi@redhat.com>