### PR TITLE
update to tox-lsr 2.4.0 - add support for ansible-test sanity with docker

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,7 +3,8 @@ name: tox
 on:  # yamllint disable-line rule:truthy
   - pull_request
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.2.0"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.4.0"
+  LSR_ANSIBLE_TEST_DOCKER: "true"
   LSR_ANSIBLES: 'ansible==2.8.* ansible==2.9.*'
   LSR_MSCENARIOS: default
   # LSR_EXTRA_PACKAGES: "libdbus-1-dev libgirepository1.0-dev python3-dev"


### PR DESCRIPTION
set `LSR_ANSIBLE_TEST_DOCKER: "true"` so that we run ansible-test sanity
with docker
This should fix issues we are seeing with tox ansible-test failures