### PR TITLE
fix python black issues

### DIFF
--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -1175,7 +1175,7 @@ class NMUtil:
         return True
 
     def create_checkpoint(self, timeout):
-        """ Create a new checkpoint """
+        """Create a new checkpoint"""
         checkpoint = Util.call_async_method(
             self.nmclient,
             "checkpoint_create",
@@ -1192,11 +1192,11 @@ class NMUtil:
         return None
 
     def destroy_checkpoint(self, path):
-        """ Destroy the specified checkpoint """
+        """Destroy the specified checkpoint"""
         Util.call_async_method(self.nmclient, "checkpoint_destroy", [path])
 
     def rollback_checkpoint(self, path):
-        """ Rollback the specified checkpoint """
+        """Rollback the specified checkpoint"""
         Util.call_async_method(
             self.nmclient,
             "checkpoint_rollback",
@@ -1863,10 +1863,10 @@ class Cmd(object):
                     )
 
     def start_transaction(self):
-        """ Hook before making changes """
+        """Hook before making changes"""
 
     def finish_transaction(self):
-        """ Hook for after all changes where made successfuly """
+        """Hook for after all changes where made successfuly"""
 
     def rollback_transaction(self, idx, action, error):
         """Hook if configuring a profile results in an error
@@ -1885,7 +1885,7 @@ class Cmd(object):
         )
 
     def on_failure(self):
-        """ Hook to do any cleanup on failure before exiting """
+        """Hook to do any cleanup on failure before exiting"""
         pass
 
     def run_action_absent(self, idx):

--- a/module_utils/network_lsr/utils.py
+++ b/module_utils/network_lsr/utils.py
@@ -138,7 +138,7 @@ class Util:
 
     @classmethod
     def call_async_method(cls, object_, action, args, mainloop_timeout=10):
-        """ Asynchronously call a NetworkManager method """
+        """Asynchronously call a NetworkManager method"""
         cancellable = cls.create_cancellable()
         async_action = action + "_async"
         # NM does not use a uniform naming for the async methods,

--- a/tests/unit/test_network_connections.py
+++ b/tests/unit/test_network_connections.py
@@ -2795,13 +2795,13 @@ class TestValidator(unittest.TestCase):
         )
 
     def test_interface_name_ethernet_default(self):
-        """ Use the profile name as interface_name for ethernet profiles """
+        """Use the profile name as interface_name for ethernet profiles"""
         cons_without_interface_name = [{"name": "eth0", "type": "ethernet"}]
         connections = ARGS_CONNECTIONS.validate(cons_without_interface_name)
         self.assertTrue(connections[0]["interface_name"] == "eth0")
 
     def test_interface_name_ethernet_mac(self):
-        """ Do not set interface_name when mac is specified """
+        """Do not set interface_name when mac is specified"""
         cons_without_interface_name = [
             {"name": "eth0", "type": "ethernet", "mac": "3b:0b:88:16:6d:1a"}
         ]
@@ -2809,7 +2809,7 @@ class TestValidator(unittest.TestCase):
         self.assertTrue(connections[0]["interface_name"] is None)
 
     def test_interface_name_ethernet_empty(self):
-        """ Allow not to restrict the profile to an interface """
+        """Allow not to restrict the profile to an interface"""
         network_connections = [
             {"name": "internal_network", "type": "ethernet", "interface_name": ""}
         ]
@@ -2818,7 +2818,7 @@ class TestValidator(unittest.TestCase):
         self.assertTrue(connections[0]["interface_name"] is None)
 
     def test_interface_name_ethernet_None(self):
-        """ Check that interface_name cannot be None """
+        """Check that interface_name cannot be None"""
         network_connections = [
             {"name": "internal_network", "type": "ethernet", "interface_name": None}
         ]
@@ -2827,7 +2827,7 @@ class TestValidator(unittest.TestCase):
         )
 
     def test_interface_name_ethernet_explicit(self):
-        """ Use the explicitly provided interface name """
+        """Use the explicitly provided interface name"""
         network_connections = [
             {"name": "internal", "type": "ethernet", "interface_name": "eth0"}
         ]

--- a/tests/unit/test_nm_provider.py
+++ b/tests/unit/test_nm_provider.py
@@ -25,14 +25,14 @@ with mock.patch.dict("sys.modules", {"gi": mock.Mock(), "gi.repository": mock.Mo
 
 
 def test_get_nm_ethtool_feature():
-    """ Test get_nm_ethtool_feature() """
+    """Test get_nm_ethtool_feature()"""
     with mock.patch.object(nm_provider.Util, "NM") as nm_mock:
         nm_feature = nm_provider.get_nm_ethtool_feature("esp_hw_offload")
     assert nm_feature == nm_mock.return_value.ETHTOOL_OPTNAME_FEATURE_ESP_HW_OFFLOAD
 
 
 def test_get_nm_ethtool_coalesce():
-    """ Test get_nm_ethtool_coalesce() """
+    """Test get_nm_ethtool_coalesce()"""
     with mock.patch.object(nm_provider.Util, "NM") as nm_mock:
         nm_feature = nm_provider.get_nm_ethtool_coalesce("rx_frames")
     assert nm_feature == nm_mock.return_value.ETHTOOL_OPTNAME_COALESCE_RX_FRAMES


### PR DESCRIPTION
There was recently an upgrade to python black which made function
documentation checking stricter.  This caused network tox CI to
break.  The fix is to format the function doc text in the manner
expected by black.