### PR TITLE
Enable comment support for "NM_ONLY_TESTS"

### DIFF
--- a/tests/ensure_provider_tests.py
+++ b/tests/ensure_provider_tests.py
@@ -49,7 +49,7 @@ RUN_PLAYBOOK_WITH_NM = """# SPDX-License-Identifier: BSD-3-Clause
 
 # The test requires or should run with NetworkManager, therefore it cannot run
 # on RHEL/CentOS 6
-- import_playbook: {test_playbook}
+{comment}- import_playbook: {test_playbook}
   when:
     - ansible_distribution_major_version != '6'
 {minimum_nm_version_check}{extra_run_condition}"""
@@ -119,6 +119,7 @@ def create_nm_playbook(test_playbook):
     extra_run_condition = NM_ONLY_TESTS.get(test_playbook, {}).get(
         EXTRA_RUN_CONDITION, ""
     )
+    comment = NM_ONLY_TESTS.get(test_playbook, {}).get("comment", "")
     if extra_run_condition:
         extra_run_condition = f"{EXTRA_RUN_CONDITION_PREFIX}{extra_run_condition}\n"
 
@@ -127,10 +128,13 @@ def create_nm_playbook(test_playbook):
         nm_version_check = MINIMUM_NM_VERSION_CHECK.format(
             minimum_nm_version=minimum_nm_version
         )
+    if comment:
+        comment = f"{comment}\n"
 
     nominal_nm_testfile_data = RUN_PLAYBOOK_WITH_NM.format(
         test_playbook=test_playbook,
         get_nm_version=minimum_nm_version and GET_NM_VERSION or "",
+        comment=comment,
         minimum_nm_version_check=nm_version_check,
         extra_run_condition=extra_run_condition,
     )

--- a/tests/tests_ethtool_coalesce_nm.yml
+++ b/tests/tests_ethtool_coalesce_nm.yml
@@ -28,12 +28,9 @@
         - always
 
 
-# workaround for: https://github.com/ansible/ansible/issues/27973
-# There is no way in Ansible to abort a playbook hosts with specific OS
-# releases Therefore we include the playbook with the tests only if the hosts
-# would support it.
 # The test requires or should run with NetworkManager, therefore it cannot run
 # on RHEL/CentOS 6
+# NetworkManager 1.25.1 introduced ethtool coalesce support
 - import_playbook: playbooks/tests_ethtool_coalesce.yml
   when:
     - ansible_distribution_major_version != '6'

--- a/tests/tests_ethtool_features_nm.yml
+++ b/tests/tests_ethtool_features_nm.yml
@@ -5,8 +5,6 @@
 - hosts: all
   name: Run playbook 'playbooks/tests_ethtool_features.yml' with nm as provider
   tasks:
-    - include_tasks: tasks/el_repo_setup.yml
-
     - name: Set network provider to 'nm'
       set_fact:
         network_provider: nm
@@ -32,6 +30,7 @@
 
 # The test requires or should run with NetworkManager, therefore it cannot run
 # on RHEL/CentOS 6
+# NetworkManager 1.20.0 introduced ethtool settings support
 - import_playbook: playbooks/tests_ethtool_features.yml
   when:
     - ansible_distribution_major_version != '6'

--- a/tests/tests_provider_nm.yml
+++ b/tests/tests_provider_nm.yml
@@ -5,8 +5,6 @@
 - hosts: all
   name: Run playbook 'playbooks/tests_provider.yml' with nm as provider
   tasks:
-    - include_tasks: tasks/el_repo_setup.yml
-
     - name: Set network provider to 'nm'
       set_fact:
         network_provider: nm
@@ -32,6 +30,7 @@
 
 # The test requires or should run with NetworkManager, therefore it cannot run
 # on RHEL/CentOS 6
+# NetworKmanager 1.20.0 added support for forgetting profiles
 - import_playbook: playbooks/tests_provider.yml
   when:
     - ansible_distribution_major_version != '6'


### PR DESCRIPTION
To clearly explain to user why minimum version or extra running
condition is needed for certain "NM_ONLY_TESTS", include additional
comment support.

Signed-off-by: Wen Liang <liangwen12year@gmail.com>