### PR TITLE
tag 802-1x, bond tests as expfail; bridge test cleanup

### DIFF
--- a/tests/playbooks/tests_802_1x.yml
+++ b/tests/playbooks/tests_802_1x.yml
@@ -3,6 +3,8 @@
 - hosts: all
   vars:
     interface: 802-1x-test
+  tags:
+    - tests::expfail
   tasks:
     - name: "INIT: 802.1x tests"
       debug:

--- a/tests/playbooks/tests_bond.yml
+++ b/tests/playbooks/tests_bond.yml
@@ -8,6 +8,8 @@
     dhcp_interface1: test1
     port2_profile: bond0.1
     dhcp_interface2: test2
+  tags:
+    - tests::expfail
   tasks:
     - name: "INIT Prepare setup"
       debug:

--- a/tests/playbooks/tests_bond_deprecated.yml
+++ b/tests/playbooks/tests_bond_deprecated.yml
@@ -8,6 +8,8 @@
     dhcp_interface1: test1
     port2_profile: bond0.1
     dhcp_interface2: test2
+  tags:
+    - tests::expfail
   tasks:
     - name: "INIT Prepare setup"
       debug:

--- a/tests/playbooks/tests_bridge.yml
+++ b/tests/playbooks/tests_bridge.yml
@@ -49,6 +49,16 @@
     profile: "{{ interface }}"
     task: tasks/assert_profile_absent.yml
 
+- name: Remove test bridge
+  hosts: all
+  tags:
+    - tests::cleanup
+  tasks:
+    - name: Remove the test interface
+      command: ip link delete {{ interface | quote }}
+      ignore_errors: yes
+      changed_when: false
+
 # FIXME: Devices might still be left when profile is absent
 # - import_playbook: run_tasks.yml
 #   vars:

--- a/tests/tests_bond_deprecated_initscripts.yml
+++ b/tests/tests_bond_deprecated_initscripts.yml
@@ -10,5 +10,6 @@
         network_provider: initscripts
       tags:
         - always
+        - tests::expfail
 
 - import_playbook: playbooks/tests_bond_deprecated.yml

--- a/tests/tests_bond_initscripts.yml
+++ b/tests/tests_bond_initscripts.yml
@@ -10,5 +10,6 @@
         network_provider: initscripts
       tags:
         - always
+        - tests::expfail
 
 - import_playbook: playbooks/tests_bond.yml


### PR DESCRIPTION
The 802-1x test will fail on platforms where `hostapd` is not available,
so tag that test to make it skippable.

The initscripts bridge test does not clean up properly, leaving the
device around which causes the nm test to fail.  Explicitly remove
the device for cleanup.

The bond tests do not work when being run sequentially on the same
machine as in the smoke test scenario, so tag those tests so that
they can be skipped.