### PR TITLE
fix: dhclient is already running for `nm-bond`

### DIFF
--- a/tests/playbooks/tests_bond_deprecated.yml
+++ b/tests/playbooks/tests_bond_deprecated.yml
@@ -3,7 +3,7 @@
 - hosts: all
   vars:
     controller_profile: bond0
-    controller_device: nm-bond
+    controller_device: deprecated-bond
     port1_profile: bond0.0
     dhcp_interface1: test1
     port2_profile: bond0.1


### PR DESCRIPTION
Running `tests_bond_deprecated_initscripts.yml` and
`tests_bond_initscripts.yml` consecutively will fail in the downstream
testing with error "Determining IP information for nm-bond...dhclient is already running - exiting.".
Because the two tests have the same controller device name and dhclient
will always running for the controller device `nm-bond`.

A workaround for this bug is to change the controller device name
associated with `tests_bond_deprecated_initscripts.yml`.

Signed-off-by: Wen Liang <wenliang@redhat.com>