### PR TITLE
EPEL yum repository configuration for tests

### DIFF
--- a/tests/tasks/enable_epel.yml
+++ b/tests/tasks/enable_epel.yml
@@ -1,11 +1,27 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- name: Enable EPEL {{ ansible_distribution_major_version }}
-  # yamllint disable-line rule:line-length
-  command: yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
-  args:
-    warn: false
-    creates: /etc/yum.repos.d/epel.repo
+- block:
+    - name: Create EPEL {{ ansible_distribution_major_version }}
+      # yamllint disable-line rule:line-length
+      command: yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+      args:
+        warn: false
+        creates: /etc/yum.repos.d/epel.repo
+
+    - name: Retrieve EPEL {{ ansible_distribution_major_version }} file stats
+      stat:
+        path: /etc/yum.repos.d/epel.repo
+      register: _result
+
+    - name: Enable EPEL {{ ansible_distribution_major_version }}
+      ini_file:
+        path: /etc/yum.repos.d/epel.repo
+        section: epel
+        mode: "{{ _result.stat.mode }}"
+        owner: "{{ _result.stat.pw_name }}"
+        group: "{{ _result.stat.gr_name }}"
+        option: enabled
+        value: "1"
   when:
     - ansible_distribution in ['RedHat', 'CentOS']
     - ansible_distribution_major_version in ['7', '8']


### PR DESCRIPTION
In tests/tasks/enable_epel.yml, if /etc/yum.repos.d/epel.repo exists
and it is not enabled, it's left disabled. Without the epel enabled,
it fails to install necessary modules such as python-mock, which
makes tests_unit.yml and tests_wireless_nm.yml fail.

This patch adds a task calling ini_file to ensure the repo is always
enabled. See also bz1980439.