### PR TITLE
test: Restore the resolv.conf for bond dhcp test

### DIFF
--- a/tests/playbooks/tests_bond.yml
+++ b/tests/playbooks/tests_bond.yml
@@ -19,6 +19,10 @@
     - import_tasks: tasks/assert_device_present.yml
       vars:
         interface: "{{ dhcp_interface2 }}"
+    - name: "Backup the /etc/resolv.conf for initscript"
+      command: cp -vf /etc/resolv.conf /etc/resolv.conf.bak
+      when:
+        - network_provider == "initscripts"
     - block:
         - name: "TEST Add Bond with 2 ports"
           debug:
@@ -93,5 +97,9 @@
             - command: ip link del {{ controller_device }}
               ignore_errors: true
             - import_tasks: tasks/remove_test_interfaces_with_dhcp.yml
+            - name: "Restore the /etc/resolv.conf for initscript"
+              command: mv -vf /etc/resolv.conf.bak /etc/resolv.conf
+              when:
+                - network_provider == "initscripts"
           tags:
             - "tests::cleanup"


### PR DESCRIPTION
The `tests_bond_initscripts.yml` will leave the VM holding the testing
DNS entry (nameserver 192.0.2.1) which break network connection.

The root cause is initscript will use dhcp-client for bond DHCP testing
which override the /etc/resolv.conf file. After test bond interface been
removed, the initscript will not restore the DNS settings.

The fix is backup the /etc/resolv.conf and restore it on clean up for
initscript provider.