### PR TITLE
fix: pytest not reproducible in RHEL8

### DIFF
--- a/tests/playbooks/integration_pytest_python3.yml
+++ b/tests/playbooks/integration_pytest_python3.yml
@@ -131,6 +131,10 @@
                 var: playbook_run.stdout_lines
 
         - block:
+            - name: install network-scripts when running pytest with initscripts
+              package:
+                name: network-scripts
+                state: present
             - name: Run pytest with initscripts
               command: >
                 pytest


### PR DESCRIPTION
Previously when we run `tests_integration_pytest.yml` in RHEL 8, device
becoming unmanaged and NM `ifup` command failed to bring up the
connection when running pytest with initscripts, because network scripts
are deprecated in RHEL8 and they are no longer provided by default.

To fix that, install `network-scripts` package to utilize the legacy
`ifup` command.

Signed-off-by: Wen Liang <liangwen12year@gmail.com>