### PR TITLE
tests: allow executing `pytest test_network_connections.py` directly

### DIFF
--- a/tests/unit/fake_env/ansible/module_utils/network_lsr
+++ b/tests/unit/fake_env/ansible/module_utils/network_lsr
@@ -1,0 +1,1 @@
+../../../../module_utils/network_lsr

--- a/tests/unit/fake_env/network_connections.py
+++ b/tests/unit/fake_env/network_connections.py
@@ -1,0 +1,1 @@
+../../../library/network_connections.py

--- a/tests/unit/fake_env/network_lsr
+++ b/tests/unit/fake_env/network_lsr
@@ -1,0 +1,1 @@
+../../../module_utils/network_lsr

--- a/tests/unit/test_network_connections.py
+++ b/tests/unit/test_network_connections.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import copy
 import itertools
+import os
 import pprint as pprint_
 import socket
 import sys
@@ -15,9 +16,12 @@ except ImportError:  # py2
 
 sys.modules["ansible.module_utils.basic"] = mock.Mock()
 
-# pylint: disable=import-error, wrong-import-position
+try:
+    import network_lsr
+except ImportError:
+    sys.path.append(os.path.join(os.path.dirname(__file__), "fake_env"))
+    import network_lsr
 
-import network_lsr
 import network_lsr.argument_validator
 from network_connections import IfcfgUtil, NMUtil, SysUtil, Util
 from network_lsr.argument_validator import ValidationError


### PR DESCRIPTION
Unit tests are important for development, and the ability to run them
directly, without tox etc.

Fake the environment so that `test_network_connections.py` can be run
directly via
```
  $ pytest tests/unit/test_network_connections.py -v
```