### PR TITLE
Skip tests on RHEL9 that use hostapd

### DIFF
--- a/tests/ensure_provider_tests.py
+++ b/tests/ensure_provider_tests.py
@@ -57,8 +57,14 @@ RUN_PLAYBOOK_WITH_NM = """# SPDX-License-Identifier: BSD-3-Clause
 MINIMUM_VERSION = "minimum_version"
 EXTRA_RUN_CONDITION = "extra_run_condition"
 NM_ONLY_TESTS = {
-    "playbooks/tests_802_1x_updated.yml": {},
-    "playbooks/tests_802_1x.yml": {},
+    "playbooks/tests_802_1x_updated.yml": {
+        EXTRA_RUN_CONDITION: "ansible_distribution != 'RedHat' or\n      ansible_distr\
+ibution_major_version | int < 9",
+    },
+    "playbooks/tests_802_1x.yml": {
+        EXTRA_RUN_CONDITION: "ansible_distribution != 'RedHat' or\n      ansible_distr\
+ibution_major_version | int < 9",
+    },
     "playbooks/tests_eth_dns_support.yml": {},
     "playbooks/tests_dummy.yml": {},
     "playbooks/tests_ethtool_features.yml": {

--- a/tests/tests_802_1x_nm.yml
+++ b/tests/tests_802_1x_nm.yml
@@ -5,7 +5,6 @@
 - hosts: all
   name: Run playbook 'playbooks/tests_802_1x.yml' with nm as provider
   tasks:
-    - include_tasks: tasks/el_repo_setup.yml
     - name: Set network provider to 'nm'
       set_fact:
         network_provider: nm
@@ -18,3 +17,5 @@
 - import_playbook: playbooks/tests_802_1x.yml
   when:
     - ansible_distribution_major_version != '6'
+    - ansible_distribution != 'RedHat' or
+      ansible_distribution_major_version | int < 9

--- a/tests/tests_802_1x_updated_nm.yml
+++ b/tests/tests_802_1x_updated_nm.yml
@@ -5,7 +5,6 @@
 - hosts: all
   name: Run playbook 'playbooks/tests_802_1x_updated.yml' with nm as provider
   tasks:
-    - include_tasks: tasks/el_repo_setup.yml
     - name: Set network provider to 'nm'
       set_fact:
         network_provider: nm
@@ -18,3 +17,5 @@
 - import_playbook: playbooks/tests_802_1x_updated.yml
   when:
     - ansible_distribution_major_version != '6'
+    - ansible_distribution != 'RedHat' or
+      ansible_distribution_major_version | int < 9


### PR DESCRIPTION
The tests expect there is a hostapd package for doing wireless testing,
and that this package comes from EPEL on EL platforms.  Since there
is no EPEL9, skip tests that require hostapd.