### PR TITLE
CI: Enable integration test in Github Action

### DIFF
--- a/.github/Dockerfile.c8-network-role
+++ b/.github/Dockerfile.c8-network-role
@@ -1,0 +1,12 @@
+FROM quay.io/centos/centos:8
+
+RUN dnf -y install dnf-plugins-core epel-release && \
+    dnf config-manager --set-enabled powertools && \
+    dnf -y upgrade && \
+    dnf -y install NetworkManager NetworkManager-wifi \
+    procps-ng iproute ansible openssh-server openssh-clients systemd-udev \
+    dnsmasq hostapd wpa_supplicant openssl ethtool iputils python3-gobject-base
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]

--- a/.github/Dockerfile.c8s-network-role
+++ b/.github/Dockerfile.c8s-network-role
@@ -1,0 +1,12 @@
+FROM quay.io/centos/centos:stream8
+
+RUN dnf -y install dnf-plugins-core epel-release && \
+    dnf config-manager --set-enabled powertools && \
+    dnf -y upgrade && \
+    dnf -y install NetworkManager NetworkManager-wifi \
+    procps-ng iproute ansible openssh-server openssh-clients systemd-udev \
+    dnsmasq hostapd wpa_supplicant openssl ethtool iputils python3-gobject-base
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]

--- a/.github/run_test.sh
+++ b/.github/run_test.sh
@@ -1,0 +1,122 @@
+#!/bin/bash -x
+
+TEST_SOURCE_DIR="/network-role"
+C8S_CONTAINER_IMAGE="quay.io/linux_system_roles/c8s-network-role"
+C8_CONTAINER_IMAGE="quay.io/linux_system_roles/c8-network-role"
+PODMAN_OPTS="--systemd=true --privileged"
+
+read -d '' TEST_FILES << EOF
+tests_802_1x_nm.yml
+tests_bond_nm.yml
+tests_auto_gateway_nm.yml
+tests_bridge_nm.yml
+tests_change_indication_on_repeat_run.yml
+tests_dummy_nm.yml
+tests_eth_dns_support_nm.yml
+tests_ethtool_coalesce_nm.yml
+tests_ethtool_features_nm.yml
+tests_ethtool_ring_nm.yml
+tests_ipv6_disabled_nm.yml
+tests_ipv6_nm.yml
+tests_vlan_mtu_nm.yml
+tests_wireless_nm.yml
+EOF
+
+EXEC_PATH=$(dirname "$(realpath "$0")")
+PROJECT_PATH=$(dirname "$(realpath "$EXEC_PATH../")")
+
+# Default to CentOS 8
+OS_TYPE=c8
+
+while [[ $# -gt 0 ]]; do
+    key="$1"
+
+    case $key in
+        --os)
+            OS_TYPE=$2
+            shift # past argument
+            shift # past value
+            ;;
+        *)    # unknown option
+            echo "Unknown option, please try $1 --os c8s"
+            exit 1
+            ;;
+    esac
+done
+
+case $OS_TYPE in
+    "c8s")
+        CONTAINER_IMAGE=$C8S_CONTAINER_IMAGE
+        ;;
+    "c8")
+        CONTAINER_IMAGE=$C8_CONTAINER_IMAGE
+        ;;
+    *)
+        echo "Unsupported OS type $OS_TYPE"
+        exit 1
+        ;;
+esac
+
+CONTAINER_ID=`podman run -d $PODMAN_OPTS \
+    -v $PROJECT_PATH:$TEST_SOURCE_DIR $CONTAINER_IMAGE`
+
+if [ -z "$CONTAINER_ID" ];then
+    echo "Failed to start container"
+    exit 1
+fi
+
+function clean_up {
+    podman rm -f $CONTAINER_ID || true
+}
+
+if [ -z "$DEBUG" ];then
+    trap clean_up ERR EXIT
+fi
+
+# Ensure we quit on first failure
+set -e
+
+# Ensure we are testing the latest packages and ignore upgrade failure
+sudo podman exec -i $CONTAINER_ID /bin/bash -c  'dnf upgrade -y' || true
+
+podman exec -i $CONTAINER_ID \
+    /bin/bash -c  \
+        'while ! systemctl is-active dbus; do sleep 1; done'
+
+podman exec -i $CONTAINER_ID \
+    /bin/bash -c  'sysctl -w net.ipv6.conf.all.disable_ipv6=0'
+
+sudo podman exec -i $CONTAINER_ID \
+        /bin/bash -c  \
+                'systemctl start systemd-udevd;
+        while ! systemctl is-active systemd-udevd; do sleep 1; done'
+
+
+podman exec -i $CONTAINER_ID \
+    /bin/bash -c  \
+        'systemctl restart NetworkManager;
+         while ! systemctl is-active NetworkManager; do sleep 1; done'
+
+podman exec -i $CONTAINER_ID \
+    /bin/bash -c  \
+        'systemctl restart sshd;
+         while ! systemctl is-active sshd; do sleep 1; done'
+
+podman exec -i $CONTAINER_ID \
+    /bin/bash -c  \
+        'cat /dev/zero | ssh-keygen -q -N "";
+         cp -v /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys'
+
+for test_file in $TEST_FILES; do
+    podman exec -i $CONTAINER_ID \
+        /bin/bash -c  \
+            "cd $TEST_SOURCE_DIR;
+             env ANSIBLE_HOST_KEY_CHECKING=False \
+                 ansible-playbook -i localhost, \
+                 ./tests/$test_file"
+done
+
+if [ -n "$DEBUG" ];then
+    podman exec -it $CONTAINER_ID bash
+    clean_up
+fi

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,24 @@
+name: integration
+
+on:
+  pull_request:
+   types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - base
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: "c8"
+          - os: "c8s"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        run: sudo .github/run_test.sh --os ${{ matrix.os }}

--- a/tests/tasks/create_test_interfaces_with_dhcp.yml
+++ b/tests/tasks/create_test_interfaces_with_dhcp.yml
@@ -8,21 +8,24 @@
 
 - name: Create test interfaces
   shell: |
-    # NM to see veth devices starting with test* as managed after ip add..
-    echo 'ENV{ID_NET_DRIVER}=="veth",\
-          ENV{INTERFACE}=="test*", \
-          ENV{NM_UNMANAGED}="0"' >/etc/udev/rules.d/88-veth.rules
-    udevadm control --reload-rules
-    udevadm settle --timeout=5
-
-    # Setuptwo devices with IPv4/IPv6 auto support
     ip link add {{ dhcp_interface1 }} type veth peer name {{ dhcp_interface1 }}p
-    ip link set {{ dhcp_interface1 }}p up
     ip link add {{ dhcp_interface2 }} type veth peer name {{ dhcp_interface2 }}p
+    if [ -n "$(pidof NetworkManager)" ];then
+      nmcli d set {{ dhcp_interface1 }} managed true
+      nmcli d set {{ dhcp_interface2 }} managed true
+      # NetworkManager should not manage DHCP server ports
+      nmcli d set {{ dhcp_interface1 }}p managed false
+      nmcli d set {{ dhcp_interface2 }}p managed false
+    fi
+    ip link set {{ dhcp_interface1 }}p up
     ip link set {{ dhcp_interface2 }}p up
 
     # Create the 'testbr' - providing both 10.x ipv4 and 2620:52:0 ipv6 dhcp
     ip link add name testbr type bridge forward_delay 0
+    if [ -n "$(pidof NetworkManager)" ];then
+      # NetworkManager should not manage DHCP server ports
+      nmcli d set testbr managed false
+    fi
     ip link set testbr up
     ip addr add 192.0.2.1/24 dev testbr
     ip -6 addr add 2001:DB8::1/32 dev testbr

--- a/tests/tasks/remove_test_interfaces_with_dhcp.yml
+++ b/tests/tasks/remove_test_interfaces_with_dhcp.yml
@@ -5,11 +5,6 @@
     ip link delete {{ dhcp_interface1 }}
     ip link delete {{ dhcp_interface2 }}
     ip link delete testbr
-
-    # Remove udev rule for NM to see veth devices starting with test*.....
-    rm -rf /etc/udev/rules.d/88-veth.rules
-    udevadm control --reload-rules
-    udevadm settle --timeout=5
   changed_when: false
 
 


### PR DESCRIPTION
Using container to run `ansible-playbook` against localhost.

To debug it, try

```bash
sudo DEBUG=1 ./.github/run_test.sh tests_bond_nm.yml
```

Attached two container files for CentOS 8 and CentOS Stream 8.
The container image is stored under quay:
    https://quay.io/repository/linux_system_roles

Only a small mount of tests has been chose in order to give stable CI
test feedback.

The github action CI will run two instances using above container image.
