### PR TITLE
should not have removed epel setup from 802 tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,7 +2,7 @@ name: integration
 
 on:
   pull_request:
-   types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - base

--- a/tests/tests_802_1x_nm.yml
+++ b/tests/tests_802_1x_nm.yml
@@ -5,6 +5,7 @@
 - hosts: all
   name: Run playbook 'playbooks/tests_802_1x.yml' with nm as provider
   tasks:
+    - include_tasks: tasks/el_repo_setup.yml
     - name: Set network provider to 'nm'
       set_fact:
         network_provider: nm

--- a/tests/tests_802_1x_updated_nm.yml
+++ b/tests/tests_802_1x_updated_nm.yml
@@ -5,6 +5,7 @@
 - hosts: all
   name: Run playbook 'playbooks/tests_802_1x_updated.yml' with nm as provider
   tasks:
+    - include_tasks: tasks/el_repo_setup.yml
     - name: Set network provider to 'nm'
       set_fact:
         network_provider: nm


### PR DESCRIPTION
The commit b4584c88a8064aff9de84a15439b91772cb00bec to skip
tests that use hostapd also removed the epel repo setup.  This
breaks other platforms that require epel.