### PR TITLE
[citest skip] CI: Enable CentOS 9 stream integration test

### DIFF
--- a/.github/Dockerfile.c9s-network-role
+++ b/.github/Dockerfile.c9s-network-role
@@ -1,0 +1,14 @@
+FROM quay.io/centos/centos:stream9-development
+
+RUN dnf -y install dnf-plugins-core && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y upgrade && \
+    dnf -y install NetworkManager NetworkManager-wifi \
+        procps-ng iproute openssh-server openssh-clients systemd-udev \
+        dnsmasq wpa_supplicant openssl ethtool iputils python3-gobject-base \
+        python3-pip python3-jmespath && \
+    pip3 install ansible==2.9.*
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]

--- a/.github/run_test.sh
+++ b/.github/run_test.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 TEST_SOURCE_DIR="/network-role"
 C8S_CONTAINER_IMAGE="quay.io/linux-system-roles/c8s-network-role"
 C7_CONTAINER_IMAGE="quay.io/linux-system-roles/c7-network-role"
+C9S_CONTAINER_IMAGE="quay.io/linux-system-roles/c9s-network-role"
 PODMAN_OPTS="--systemd=true --privileged"
 
 # FIXME: test_wireless has been removed because is not supported on CI
@@ -55,6 +56,9 @@ case $OS_TYPE in
         ;;
     "c7")
         CONTAINER_IMAGE=$C7_CONTAINER_IMAGE
+        ;;
+    "c9s")
+        CONTAINER_IMAGE=$C9S_CONTAINER_IMAGE
         ;;
     *)
         echo "Unsupported OS type $OS_TYPE"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,6 +16,7 @@ jobs:
         include:
           - os: "c7"
           - os: "c8s"
+          - os: "c9s"
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Skipped the 802.1x test due to missing hostapd rpm.