### PR TITLE
On RHEL 7, enable epel using yum-config-manager

### DIFF
--- a/tests/tasks/enable_epel.yml
+++ b/tests/tasks/enable_epel.yml
@@ -9,7 +9,7 @@
         creates: /etc/yum.repos.d/epel.repo
 
     - name: Enable EPEL 7
-      command: yum config-manager --set-enabled epel
+      command: yum-config-manager --enable epel
       when: ansible_distribution_major_version == '7'
       args:
         warn: false


### PR DESCRIPTION
Fixing the CI on RHEL 7, it was broken by PR #422