### PR TITLE
reject `dns` setting if IPv6 is not configured

### DIFF
--- a/tests/unit/test_network_connections.py
+++ b/tests/unit/test_network_connections.py
@@ -3694,6 +3694,32 @@ class TestValidator(Python26CompatTestCase):
             None,
         )
 
+    def test_ipv6_dns_without_ipv6_configuration(self):
+        """
+        Test that configuring IPv6 DNS is not allowed when IPv6 is not configured.
+        """
+        validator = network_lsr.argument_validator.ArgValidator_ListConnections()
+        ipv6_dns_without_ipv6_configuration = [
+            {
+                "name": "test_ipv6_dns",
+                "type": "ethernet",
+                "ip": {
+                    "dhcp4": False,
+                    "auto6": False,
+                    "dns": ["2001:db8::20"],
+                },
+            }
+        ]
+
+        self.assertRaisesRegex(
+            ValidationError,
+            "IPv6 needs to be enabled to support IPv6 nameservers.",
+            validator.validate_connection_one,
+            "nm",
+            validator.validate(ipv6_dns_without_ipv6_configuration),
+            0,
+        )
+
     def test_ipv6_dns_options_without_ipv6_config(self):
         """
         Test that configuring IPv6 DNS options is not allowed when IPv6 is disabled.


### PR DESCRIPTION
When IPv6 is not configured, configuring IPv6 DNS should not be
allowed. Reject such a setting in argvalidator and add unit test to
verify that.

Signed-off-by: Wen Liang <liangwen12year@gmail.com>