### PR TITLE
stale robot: Disable auto close PR

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 ---
 # Configuration for probot-stale - https://github.com/probot/stale
 daysUntilStale: 30
-daysUntilClose: 14
+daysUntilClose: false
 staleLabel: stale
 markComment: >
   Thank you for your contribution! There was no activity in this pull request


### PR DESCRIPTION
Closing a PR is not polite especially we have enough man power to
do manual review and closure.