### PR TITLE
WIP: Use relative import and enable pytest unit test

### DIFF
--- a/module_utils/network_lsr/argument_validator.py
+++ b/module_utils/network_lsr/argument_validator.py
@@ -9,9 +9,8 @@ import posixpath
 import socket
 import re
 
-# pylint: disable=import-error, no-name-in-module
-from ansible.module_utils.network_lsr.myerror import MyError  # noqa:E501
-from ansible.module_utils.network_lsr.utils import Util  # noqa:E501
+from .myerror import MyError
+from .utils import Util
 
 UINT32_MAX = 0xFFFFFFFF
 

--- a/module_utils/network_lsr/nm/__init__.py
+++ b/module_utils/network_lsr/nm/__init__.py
@@ -1,11 +1,10 @@
-# Relative import is not support by ansible 2.8 yet
-# pylint: disable=import-error, no-name-in-module
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible.module_utils.network_lsr.nm import provider  # noqa:E501
+# pylint: disable=import-error
+from .provider import NetworkManagerProvider
 
-# pylint: enable=import-error, no-name-in-module
+# pylint: enable=import-error
 
-provider.NetworkManagerProvider
+NetworkManagerProvider

--- a/module_utils/network_lsr/nm/client.py
+++ b/module_utils/network_lsr/nm/client.py
@@ -6,10 +6,10 @@ __metaclass__ = type
 
 import logging
 
-# Relative import is not support by ansible 2.8 yet
-# pylint: disable=import-error, no-name-in-module
-from ansible.module_utils.network_lsr.nm import error  # noqa:E501
+from .error import LsrNetworkNmError
 
+# pylint environment does not have gobject inspection
+# pylint: disable=import-error
 import gi
 
 try:
@@ -22,7 +22,7 @@ try:
     from gi.repository import GLib  # NOQA: E402
     from gi.repository import Gio  # NOQA: E402
 
-    # pylint: enable=import-error, no-name-in-module
+    # pylint: enable=import-error
 
     NM
     GLib
@@ -62,7 +62,7 @@ class _NmMainLoop(object):
 
     def _timeout_call_back(self, _user_data):
         logging.error("Timeout")
-        self.fail(error.LsrNetworkNmError("Timeout"))
+        self.fail(LsrNetworkNmError("Timeout"))
 
     @property
     def cancellable(self):

--- a/module_utils/network_lsr/nm_provider.py
+++ b/module_utils/network_lsr/nm_provider.py
@@ -5,8 +5,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-# pylint: disable=import-error, no-name-in-module
-from ansible.module_utils.network_lsr.utils import Util  # noqa:E501
+from .utils import Util
 
 ETHTOOL_FEATURE_PREFIX = "ETHTOOL_OPTNAME_FEATURE_"
 ETHTOOL_COALESCE_PREFIX = "ETHTOOL_OPTNAME_COALESCE_"

--- a/module_utils/network_lsr/utils.py
+++ b/module_utils/network_lsr/utils.py
@@ -9,8 +9,10 @@ import socket
 import sys
 import uuid
 
-# pylint: disable=import-error, no-name-in-module
-from ansible.module_utils.network_lsr.myerror import MyError  # noqa:E501
+# pylint: disable=import-error
+from .myerror import MyError
+
+# pylint: enable=import-error
 
 
 class Util:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+""" pytest environment setup """
+# SPDX-License-Identifier: BSD-3-Clause
+
+import sys
+import os
+
+try:
+    from unittest import mock
+except ImportError:  # py2
+    import mock
+
+project_path = os.path.abspath(os.path.dirname(os.path.realpath(__file__)) + "/../../")
+sys.path.append(project_path + "/library")
+sys.path.append(project_path + "/module_utils")
+
+import network_lsr
+
+__metaclass__ = type
+
+sys.modules["ansible.module_utils.basic"] = mock.Mock()
+sys.modules["ansible.module_utils.network_lsr"] = network_lsr

--- a/tests/unit/test_network_connections.py
+++ b/tests/unit/test_network_connections.py
@@ -5,22 +5,12 @@ import copy
 import itertools
 import pprint as pprint_
 import socket
-import sys
 import unittest
-
-try:
-    from unittest import mock
-except ImportError:  # py2
-    import mock
-
-sys.modules["ansible.module_utils.basic"] = mock.Mock()
-
-# pylint: disable=import-error, wrong-import-position
 
 import network_lsr
 import network_lsr.argument_validator
 from network_connections import IfcfgUtil, NMUtil, SysUtil, Util
-from network_lsr.argument_validator import ValidationError
+from ansible.module_utils.network_lsr.argument_validator import ValidationError
 
 try:
     my_test_skipIf = unittest.skipIf

--- a/tests/unit/test_nm_provider.py
+++ b/tests/unit/test_nm_provider.py
@@ -2,26 +2,12 @@
 """ Tests for network_connections Ansible module """
 # SPDX-License-Identifier: BSD-3-Clause
 
-import os
-import sys
-
-TESTS_BASEDIR = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(1, os.path.join(TESTS_BASEDIR, "../..", "library"))
-sys.path.insert(1, os.path.join(TESTS_BASEDIR, "../..", "module_utils"))
-
 try:
     from unittest import mock
 except ImportError:  # py2
     import mock
 
-sys.modules["ansible"] = mock.Mock()
-sys.modules["ansible.module_utils.basic"] = mock.Mock()
-sys.modules["ansible.module_utils"] = mock.Mock()
-sys.modules["ansible.module_utils.network_lsr"] = __import__("network_lsr")
-
-with mock.patch.dict("sys.modules", {"gi": mock.Mock(), "gi.repository": mock.Mock()}):
-    # pylint: disable=import-error, wrong-import-position
-    from network_lsr import nm_provider
+from network_lsr import nm_provider
 
 
 def test_get_nm_ethtool_feature():


### PR DESCRIPTION
Since Ansible 2.9 is the minimum supported version, we can use relative
import instead of prefixing with `ansible.module_utils.`.

Included `conftest.py` file for pytest to setup the test environment
before invoking unit test cases.