### PR TITLE
Reject DNS_search setting if no IP family is enabled

### DIFF
--- a/module_utils/network_lsr/argument_validator.py
+++ b/module_utils/network_lsr/argument_validator.py
@@ -1974,6 +1974,12 @@ class ArgValidator_ListConnections(ArgValidatorList):
                     "Setting 'dns_search' or 'dns_options' is not allowed when "
                     "both IPv4 and IPv6 are disabled.",
                 )
+            elif not _ipv4_enabled(connection) and _ipv6_is_not_configured(connection):
+                raise ValidationError.from_connection(
+                    idx,
+                    "Setting 'dns_search' or 'dns_options' is not allowed when "
+                    "IPv4 is disabled and IPv6 is not configured.",
+                )
         # DNS options 'inet6', 'ip6-bytestring', 'ip6-dotint', 'no-ip6-dotint' are only
         # supported for IPv6 configuration, so raise errors when IPv6 is disabled
         if any(

--- a/tests/unit/test_network_connections.py
+++ b/tests/unit/test_network_connections.py
@@ -3744,6 +3744,33 @@ class TestValidator(Python26CompatTestCase):
             0,
         )
 
+    def test_dns_search_without_ipv4_and_ipv6_configuration(self):
+        """
+        Test that configuring DNS search setting is not allowed when both IPv4 and
+        IPv6 are not configured.
+        """
+        validator = network_lsr.argument_validator.ArgValidator_ListConnections()
+        dns_search_without_ipv4_and_ipv6_configuration = [
+            {
+                "name": "test_dns_search",
+                "type": "ethernet",
+                "ip": {
+                    "dhcp4": False,
+                    "auto6": False,
+                    "dns_search": ["example.com"],
+                },
+            }
+        ]
+        self.assertRaisesRegex(
+            ValidationError,
+            "Setting 'dns_search' or 'dns_options' is not allowed when IPv4 is "
+            "disabled and IPv6 is not configured",
+            validator.validate_connection_one,
+            "nm",
+            validator.validate(dns_search_without_ipv4_and_ipv6_configuration),
+            0,
+        )
+
     def test_auto6_enabled_ipv6_disabled(self):
         """
         Test that enabling `auto6` and disabling IPv6 are mutually exclusive.


### PR DESCRIPTION
NetworkManager only allows to configure the DNS options for each IP
family, when they are enabled. Therefore, reject DNS settings in
ArgValidator if no IP family is enabled.

Signed-off-by: Wen Liang <liangwen12year@gmail.com>