### PR TITLE
Disable all initscripts provider tests on Fedora

### DIFF
--- a/tests/ensure_provider_tests.py
+++ b/tests/ensure_provider_tests.py
@@ -150,8 +150,7 @@ RUN_PLAYBOOK_WITH_INITSCRIPTS = """# SPDX-License-Identifier: BSD-3-Clause
 
 - import_playbook: {test_playbook}
   when: (ansible_distribution in ['CentOS','RedHat'] and\n    \
-ansible_distribution_major_version | int < 9) or\n    \
-ansible_distribution == 'Fedora'
+ansible_distribution_major_version | int < 9)
 """
 
 

--- a/tests/tests_auto_gateway_initscripts.yml
+++ b/tests/tests_auto_gateway_initscripts.yml
@@ -13,5 +13,4 @@
 
 - import_playbook: playbooks/tests_auto_gateway.yml
   when: (ansible_distribution in ['CentOS','RedHat'] and
-    ansible_distribution_major_version | int < 9) or
-    ansible_distribution == 'Fedora'
+    ansible_distribution_major_version | int < 9)

--- a/tests/tests_bond_deprecated_initscripts.yml
+++ b/tests/tests_bond_deprecated_initscripts.yml
@@ -13,5 +13,4 @@
 
 - import_playbook: playbooks/tests_bond_deprecated.yml
   when: (ansible_distribution in ['CentOS','RedHat'] and
-    ansible_distribution_major_version | int < 9) or
-    ansible_distribution == 'Fedora'
+    ansible_distribution_major_version | int < 9)

--- a/tests/tests_bond_initscripts.yml
+++ b/tests/tests_bond_initscripts.yml
@@ -13,5 +13,4 @@
 
 - import_playbook: playbooks/tests_bond.yml
   when: (ansible_distribution in ['CentOS','RedHat'] and
-    ansible_distribution_major_version | int < 9) or
-    ansible_distribution == 'Fedora'
+    ansible_distribution_major_version | int < 9)

--- a/tests/tests_bridge_initscripts.yml
+++ b/tests/tests_bridge_initscripts.yml
@@ -13,5 +13,4 @@
 
 - import_playbook: playbooks/tests_bridge.yml
   when: (ansible_distribution in ['CentOS','RedHat'] and
-    ansible_distribution_major_version | int < 9) or
-    ansible_distribution == 'Fedora'
+    ansible_distribution_major_version | int < 9)

--- a/tests/tests_default_initscripts.yml
+++ b/tests/tests_default_initscripts.yml
@@ -9,5 +9,4 @@
 
 - import_playbook: tests_default.yml
   when: (ansible_distribution in ['CentOS','RedHat'] and
-    ansible_distribution_major_version | int < 9) or
-    ansible_distribution == 'Fedora'
+    ansible_distribution_major_version | int < 9)

--- a/tests/tests_ethernet_initscripts.yml
+++ b/tests/tests_ethernet_initscripts.yml
@@ -13,5 +13,4 @@
 
 - import_playbook: playbooks/tests_ethernet.yml
   when: (ansible_distribution in ['CentOS','RedHat'] and
-    ansible_distribution_major_version | int < 9) or
-    ansible_distribution == 'Fedora'
+    ansible_distribution_major_version | int < 9)

--- a/tests/tests_ethtool_coalesce_initscripts.yml
+++ b/tests/tests_ethtool_coalesce_initscripts.yml
@@ -13,5 +13,4 @@
 
 - import_playbook: playbooks/tests_ethtool_coalesce.yml
   when: (ansible_distribution in ['CentOS','RedHat'] and
-    ansible_distribution_major_version | int < 9) or
-    ansible_distribution == 'Fedora'
+    ansible_distribution_major_version | int < 9)

--- a/tests/tests_ethtool_features_initscripts.yml
+++ b/tests/tests_ethtool_features_initscripts.yml
@@ -13,5 +13,4 @@
 
 - import_playbook: playbooks/tests_ethtool_features.yml
   when: (ansible_distribution in ['CentOS','RedHat'] and
-    ansible_distribution_major_version | int < 9) or
-    ansible_distribution == 'Fedora'
+    ansible_distribution_major_version | int < 9)

--- a/tests/tests_ethtool_ring_initscripts.yml
+++ b/tests/tests_ethtool_ring_initscripts.yml
@@ -13,5 +13,4 @@
 
 - import_playbook: playbooks/tests_ethtool_ring.yml
   when: (ansible_distribution in ['CentOS','RedHat'] and
-    ansible_distribution_major_version | int < 9) or
-    ansible_distribution == 'Fedora'
+    ansible_distribution_major_version | int < 9)

--- a/tests/tests_ipv6_initscripts.yml
+++ b/tests/tests_ipv6_initscripts.yml
@@ -13,5 +13,4 @@
 
 - import_playbook: playbooks/tests_ipv6.yml
   when: (ansible_distribution in ['CentOS','RedHat'] and
-    ansible_distribution_major_version | int < 9) or
-    ansible_distribution == 'Fedora'
+    ansible_distribution_major_version | int < 9)

--- a/tests/tests_states_initscripts.yml
+++ b/tests/tests_states_initscripts.yml
@@ -13,5 +13,4 @@
 
 - import_playbook: playbooks/tests_states.yml
   when: (ansible_distribution in ['CentOS','RedHat'] and
-    ansible_distribution_major_version | int < 9) or
-    ansible_distribution == 'Fedora'
+    ansible_distribution_major_version | int < 9)

--- a/tests/tests_switch_provider.yml
+++ b/tests/tests_switch_provider.yml
@@ -9,4 +9,3 @@
     # run on RHEL/CentOS 7, RHEL/CentOS 8, or Fedora
     - ansible_distribution in ['CentOS', 'RedHat'] and
       ansible_distribution_major_version in ['7', '8']
-      or ansible_distribution == 'Fedora'

--- a/tests/tests_vlan_mtu_initscripts.yml
+++ b/tests/tests_vlan_mtu_initscripts.yml
@@ -13,5 +13,4 @@
 
 - import_playbook: playbooks/tests_vlan_mtu.yml
   when: (ansible_distribution in ['CentOS','RedHat'] and
-    ansible_distribution_major_version | int < 9) or
-    ansible_distribution == 'Fedora'
+    ansible_distribution_major_version | int < 9)


### PR DESCRIPTION
The initscripts provider tests are unstable on Fedora and users are not
using the initscripts on Fedora, therefore, disable all initscripts
provider tests on Fedora.

Signed-off-by: Wen Liang <liangwen12year@gmail.com>