### PR TITLE
pytest: Fix py26 unit tests

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,7 +4,7 @@ on:  # yamllint disable-line rule:truthy
   - pull_request
   - push
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.9.1"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@b7eba23c42e131b988df3dab87e52be51f0ff373"
   LSR_ANSIBLE_TEST_DOCKER: "true"
   LSR_ANSIBLES: 'ansible==2.9.*'
   LSR_MSCENARIOS: default
@@ -49,4 +49,4 @@ jobs:
       - name: checkout PR
         uses: actions/checkout@v2
       - name: Run py26 tests
-        uses: linux-system-roles/lsr-gh-action-py26@1.0.1
+        uses: linux-system-roles/lsr-gh-action-py26@1.0.2

--- a/pytest_extra_requirements.txt
+++ b/pytest_extra_requirements.txt
@@ -8,4 +8,3 @@ mock ; python_version < "3.0"
 # ansible and dependencies for all supported platforms
 ansible ; python_version > "2.6"
 idna<2.8 ; python_version < "2.7"
-PyYAML<5.1 ; python_version < "2.7"


### PR DESCRIPTION
This needs to be adjusted once tox-lsr and lsr-gh-action-py26 are released.