### PR TITLE
Fix hostapd package installation error

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -33,3 +33,4 @@ rules:
       /tests/tests_wireless_wpa3_sae_nm.yml
       /tests/tests_eth_pci_address_match_nm.yml
       /tests/playbooks/tests_eth_pci_address_match.yml
+      /tests/tasks/setup_802_1x_server.yml

--- a/tests/tasks/setup_802_1x_server.yml
+++ b/tests/tasks/setup_802_1x_server.yml
@@ -1,5 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
+# This task can be removed once the RHEL-8.5 is not tested anymore
+- name: Install hostapd via CentOS Stream
+  command: dnf -y install http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/hostapd-2.10-1.el8.x86_64.rpm
+  when:
+    - ansible_distribution_version | float < 8.6
+    - ansible_distribution_major_version == '8'
+    - ansible_distribution == 'RedHat'
+
 - name: Install hostapd
   package:
     name: hostapd


### PR DESCRIPTION
The hostapd package cannot be installed via RHEL Repo until RHEL-8.6,
as a result, any RHEL-8 of which the version released before REHL-8.6
has to install the hostapd via CentOS Stream in order to run managed
host testing.

Signed-off-by: Wen Liang <liangwen12year@gmail.com>