### PR TITLE
Remove connection profile before running pytest

### DIFF
--- a/tests/integration/test_ethernet.py
+++ b/tests/integration/test_ethernet.py
@@ -78,6 +78,15 @@ def testnic1():
         yield veth_name
     finally:
         subprocess.call(["ip", "link", "delete", veth_name])
+        if os.path.isfile("/etc/sysconfig/network-scripts/ifcfg-" + veth_name):
+            os.unlink("/etc/sysconfig/network-scripts/ifcfg-" + veth_name)
+            subprocess.call(
+                [
+                    "nmcli",
+                    "con",
+                    "reload",
+                ]
+            )
 
 
 def _get_ip_addresses(interface):


### PR DESCRIPTION
Running the pytest with nm provider failed in the downstream testing
because the "NM_CONTROLLED=no" appeared in
`/etc/sysconfig/network-scripts/ifcfg-testeth` which caused the veth
`testeth` strictly unmanaged by NetworkManager. To fix it, remove such
a connection profile when it is existed before running the pytest.

Signed-off-by: Wen Liang <liangwen12year@gmail.com>