### PR TITLE
GitHub CI: Trigger on main branch

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches:
-      - base
+      - main
 
 jobs:
   integration:


### PR DESCRIPTION
The network role is using `main` for the default branch, so this needs
to be used in the workflow definition.