### PR TITLE
InfiniBand bond: Fix typo of bond mode active-backup

### DIFF
--- a/module_utils/network_lsr/argument_validator.py
+++ b/module_utils/network_lsr/argument_validator.py
@@ -2079,7 +2079,7 @@ class ArgValidator_ListConnections(ArgValidatorList):
                             "type by '%s'" % (connection["controller"], c["type"]),
                         )
                     if connection["type"] == "infiniband":
-                        if c["type"] == "bond" and c["bond"]["mode"] != "active_backup":
+                        if c["type"] == "bond" and c["bond"]["mode"] != "active-backup":
                             raise ValidationError(
                                 name + "[" + str(idx) + "].controller",
                                 "bond only supports infiniband ports in active-backup mode",


### PR DESCRIPTION
The correct bond mode is `active-backup` instead of `active_backup`.

Thanks to vpal who found this issue via
https://github.com/linux-system-roles/network/issues/475