### PR TITLE
Instead of set_fact, use vars to set "interface"

### DIFF
--- a/tests/playbooks/tests_bond_deprecated.yml
+++ b/tests/playbooks/tests_bond_deprecated.yml
@@ -97,3 +97,8 @@
             - import_tasks: tasks/remove_test_interfaces_with_dhcp.yml
           tags:
             - "tests::cleanup"
+
+    - name: Restart NetworkManager for the tests to be followed if any
+      service:
+        name: NetworkManager
+        state: restarted

--- a/tests/playbooks/tests_bridge.yml
+++ b/tests/playbooks/tests_bridge.yml
@@ -2,19 +2,17 @@
 ---
 - name: Test configuring bridges
   hosts: all
-  vars:
-    interface: LSR-TST-br31
-
   tasks:
-    - name: "set interface={{ interface }}"
-      set_fact:
-        interface: "{{ interface }}"
-    - include_tasks: tasks/show_interfaces.yml
-    - include_tasks: tasks/assert_device_absent.yml
+    - block:
+        - include_tasks: tasks/show_interfaces.yml
+        - include_tasks: tasks/assert_device_absent.yml
+      vars:
+        interface: LSR-TST-br31
 
 - name: Add test bridge
   hosts: all
   vars:
+    interface: LSR-TST-br31
     network_connections:
       - name: "{{ interface }}"
         interface_name: "{{ interface }}"
@@ -28,27 +26,33 @@
 
 - import_playbook: run_tasks.yml
   vars:
+    interface: LSR-TST-br31
     task: tasks/assert_device_present.yml
 
 - import_playbook: run_tasks.yml
   vars:
+    interface: LSR-TST-br31
     profile: "{{ interface }}"
     task: tasks/assert_profile_present.yml
 
 - import_playbook: down_profile+delete_interface.yml
   vars:
+    interface: LSR-TST-br31
     profile: "{{ interface }}"
 # FIXME: assert profile/device down
 
 - import_playbook: remove_profile.yml
   vars:
+    interface: LSR-TST-br31
     profile: "{{ interface }}"
 
 - import_playbook: run_tasks.yml
   vars:
+    interface: LSR-TST-br31
     profile: "{{ interface }}"
     task: tasks/assert_profile_absent.yml
 
 - import_playbook: run_tasks.yml
   vars:
+    interface: LSR-TST-br31
     task: tasks/assert_device_absent.yml

--- a/tests/playbooks/tests_eth_dns_support.yml
+++ b/tests/playbooks/tests_eth_dns_support.yml
@@ -4,122 +4,122 @@
 
 - name: Test configuring ethernet devices
   hosts: all
-  vars:
-    type: veth
-    interface: ethtest0
-
-
   tasks:
-    - name: "set type={{ type }} and interface={{ interface }}"
-      set_fact:
-        type: "{{ type }}"
-        interface: "{{ interface }}"
-    - include_tasks: tasks/show_interfaces.yml
-    - include_tasks: tasks/manage_test_interface.yml
+    - block:
+        - include_tasks: tasks/show_interfaces.yml
+        - include_tasks: tasks/manage_test_interface.yml
+          vars:
+            state: present
+        - include_tasks: tasks/assert_device_present.yml
+
+        - name: Import network role
+          import_role:
+            name: linux-system-roles.network
+          vars:
+            network_connections:
+              - name: "{{ interface }}"
+                interface_name: "{{ interface }}"
+                state: up
+                type: ethernet
+                autoconnect: yes
+                ip:
+                  route_metric4: 100
+                  dhcp4: no
+                  gateway4: 192.0.2.1
+                  dns:
+                    - 192.0.2.2
+                    - 198.51.100.5
+                    - 2001:db8::20
+                  dns_search:
+                    - example.com
+                    - example.org
+                  dns_options:
+                    - rotate
+                    - timeout:1
+
+                  route_metric6: -1
+                  auto6: no
+                  gateway6: 2001:db8::1
+
+                  address:
+                    - 192.0.2.3/24
+                    - 198.51.100.3/26
+                    - 2001:db8::80/7
+
+                  route:
+                    - network: 198.51.100.128
+                      prefix: 26
+                      gateway: 198.51.100.1
+                      metric: 2
+                    - network: 198.51.100.64
+                      prefix: 26
+                      gateway: 198.51.100.6
+                      metric: 4
+                  route_append_only: no
+                  rule_append_only: yes
+
+        - name: Verify nmcli connection DNS entry for IPv4
+          shell: |
+            set -euxo pipefail
+            nmcli connection show {{ interface }} | grep ipv4.dns
+          register: ipv4_dns
+          ignore_errors: yes
+          changed_when: false
+
+        - name: Verify nmcli connection DNS entry for IPv6
+          shell: |
+            set -euxo pipefail
+            nmcli connection show {{ interface }} | grep ipv6.dns
+          register: ipv6_dns
+          ignore_errors: yes
+          changed_when: false
+
+        - name: "Assert that DNS addresses are configured correctly"
+          assert:
+            that:
+              - "'192.0.2.2' in ipv4_dns.stdout"
+              - "'198.51.100.5' in ipv4_dns.stdout"
+              - "'2001:db8::20' in ipv6_dns.stdout"
+            msg: "DNS addresses are configured incorrectly"
+
+        - name: "Assert that DNS search domains are configured correctly"
+          assert:
+            that:
+              - "'example.com' in ipv4_dns.stdout"
+              - "'example.org' in ipv4_dns.stdout"
+              - "'example.com' in ipv6_dns.stdout"
+              - "'example.org' in ipv6_dns.stdout"
+            msg: "DNS search domains are configured incorrectly"
+
+        - name: "Assert that DNS options are configured correctly"
+          assert:
+            that:
+              - "'rotate' in ipv4_dns.stdout"
+              - "'timeout:1' in ipv4_dns.stdout"
+              - "'rotate' in ipv6_dns.stdout"
+              - "'timeout:1' in ipv6_dns.stdout"
+            msg: "DNS options are configured incorrectly"
       vars:
-        state: present
-    - include_tasks: tasks/assert_device_present.yml
-
-    - name: Import network role
-      import_role:
-        name: linux-system-roles.network
-      vars:
-        network_connections:
-          - name: "{{ interface }}"
-            interface_name: "{{ interface }}"
-            state: up
-            type: ethernet
-            autoconnect: yes
-            ip:
-              route_metric4: 100
-              dhcp4: no
-              gateway4: 192.0.2.1
-              dns:
-                - 192.0.2.2
-                - 198.51.100.5
-                - 2001:db8::20
-              dns_search:
-                - example.com
-                - example.org
-              dns_options:
-                - rotate
-                - timeout:1
-
-              route_metric6: -1
-              auto6: no
-              gateway6: 2001:db8::1
-
-              address:
-                - 192.0.2.3/24
-                - 198.51.100.3/26
-                - 2001:db8::80/7
-
-              route:
-                - network: 198.51.100.128
-                  prefix: 26
-                  gateway: 198.51.100.1
-                  metric: 2
-                - network: 198.51.100.64
-                  prefix: 26
-                  gateway: 198.51.100.6
-                  metric: 4
-              route_append_only: no
-              rule_append_only: yes
-
-    - name: Verify nmcli connection DNS entry for IPv4
-      shell: |
-        set -euxo pipefail
-        nmcli connection show {{ interface }} | grep ipv4.dns
-      register: ipv4_dns
-      ignore_errors: yes
-      changed_when: false
-
-    - name: Verify nmcli connection DNS entry for IPv6
-      shell: |
-        set -euxo pipefail
-        nmcli connection show {{ interface }} | grep ipv6.dns
-      register: ipv6_dns
-      ignore_errors: yes
-      changed_when: false
-
-    - name: "Assert that DNS addresses are configured correctly"
-      assert:
-        that:
-          - "'192.0.2.2' in ipv4_dns.stdout"
-          - "'198.51.100.5' in ipv4_dns.stdout"
-          - "'2001:db8::20' in ipv6_dns.stdout"
-        msg: "DNS addresses are configured incorrectly"
-
-    - name: "Assert that DNS search domains are configured correctly"
-      assert:
-        that:
-          - "'example.com' in ipv4_dns.stdout"
-          - "'example.org' in ipv4_dns.stdout"
-          - "'example.com' in ipv6_dns.stdout"
-          - "'example.org' in ipv6_dns.stdout"
-        msg: "DNS search domains are configured incorrectly"
-
-    - name: "Assert that DNS options are configured correctly"
-      assert:
-        that:
-          - "'rotate' in ipv4_dns.stdout"
-          - "'timeout:1' in ipv4_dns.stdout"
-          - "'rotate' in ipv6_dns.stdout"
-          - "'timeout:1' in ipv6_dns.stdout"
-        msg: "DNS options are configured incorrectly"
+        type: veth
+        interface: ethtest0
 
 - import_playbook: down_profile+delete_interface.yml
   vars:
+    interface: ethtest0
     profile: "{{ interface }}"
 # FIXME: assert profile/device down
 - import_playbook: remove_profile.yml
   vars:
+    interface: ethtest0
     profile: "{{ interface }}"
 - name: Assert profile and device are absent
   hosts: all
   tasks:
-    - include_tasks: tasks/assert_profile_absent.yml
+    - block:
+        - include_tasks: tasks/assert_profile_absent.yml
+          vars:
+            profile: "{{ interface }}"
+        - include_tasks: tasks/assert_device_absent.yml
       vars:
-        profile: "{{ interface }}"
-    - include_tasks: tasks/assert_device_absent.yml
+        interface: ethtest0
 ...

--- a/tests/playbooks/tests_ethernet.yml
+++ b/tests/playbooks/tests_ethernet.yml
@@ -11,24 +11,26 @@
 
 - name: Test configuring ethernet devices
   hosts: all
-  vars:
-    type: veth
-    interface: lsr27
 
   tasks:
-    - name: "set type={{ type }} and interface={{ interface }}"
-      set_fact:
-        type: "{{ type }}"
-        interface: "{{ interface }}"
-    - include_tasks: tasks/show_interfaces.yml
-    - include_tasks: tasks/manage_test_interface.yml
+    - block:
+        - name: "set type={{ type }} and interface={{ interface }}"
+          set_fact:
+            type: "{{ type }}"
+            interface: "{{ interface }}"
+        - include_tasks: tasks/show_interfaces.yml
+        - include_tasks: tasks/manage_test_interface.yml
+          vars:
+            state: present
+        - include_tasks: tasks/assert_device_present.yml
       vars:
-        state: present
-    - include_tasks: tasks/assert_device_present.yml
+        type: veth
+        interface: lsr27
 
 - name: Test static interface up
   hosts: all
   vars:
+    interface: lsr27
     network_connections:
       - name: "{{ interface }}"
         interface_name: "{{ interface }}"
@@ -52,15 +54,18 @@
 # FIXME: assert profile/device up + IP address
 - import_playbook: down_profile+delete_interface.yml
   vars:
+    interface: lsr27
     profile: "{{ interface }}"
 # FIXME: assert profile/device down
 - import_playbook: remove_profile.yml
   vars:
+    interface: lsr27
     profile: "{{ interface }}"
 - name: Assert device and profile are absent
   hosts: all
   tasks:
     - include_tasks: tasks/assert_profile_absent.yml
       vars:
+        interface: lsr27
         profile: "{{ interface }}"
     - include_tasks: tasks/assert_device_absent.yml

--- a/tests/playbooks/tests_ipv6_disabled.yml
+++ b/tests/playbooks/tests_ipv6_disabled.yml
@@ -4,58 +4,62 @@
 
 - name: Test configuring ethernet devices
   hosts: all
-  vars:
-    type: veth
-    interface: ethtest0
 
   tasks:
-    - name: "set type={{ type }} and interface={{ interface }}"
-      set_fact:
-        type: "{{ type }}"
-        interface: "{{ interface }}"
-    - include_tasks: tasks/show_interfaces.yml
-    - include_tasks: tasks/manage_test_interface.yml
+    - block:
+        - name: "set type={{ type }} and interface={{ interface }}"
+          set_fact:
+            type: "{{ type }}"
+            interface: "{{ interface }}"
+        - include_tasks: tasks/show_interfaces.yml
+        - include_tasks: tasks/manage_test_interface.yml
+          vars:
+            state: present
+        - include_tasks: tasks/assert_device_present.yml
+
+        - name: Import network role
+          import_role:
+            name: linux-system-roles.network
+          vars:
+            network_connections:
+              - name: "{{ interface }}"
+                interface_name: "{{ interface }}"
+                type: ethernet
+                ip:
+                  ipv6_disabled: true
+
+        - name: Verify nmcli connection ipv6.method
+          shell: |
+            set -euxo pipefail
+            nmcli connection show {{ interface }} | grep ipv6.method
+          register: ipv6_method
+          ignore_errors: yes
+          changed_when: false
+
+        - name: "Assert that ipv6.method disabled is configured correctly"
+          assert:
+            that:
+              - "'disabled' in ipv6_method.stdout"
+            msg: "ipv6.method disabled is configured incorrectly"
       vars:
-        state: present
-    - include_tasks: tasks/assert_device_present.yml
-
-    - name: Import network role
-      import_role:
-        name: linux-system-roles.network
-      vars:
-        network_connections:
-          - name: "{{ interface }}"
-            interface_name: "{{ interface }}"
-            type: ethernet
-            ip:
-              ipv6_disabled: true
-
-    - name: Verify nmcli connection ipv6.method
-      shell: |
-        set -euxo pipefail
-        nmcli connection show {{ interface }} | grep ipv6.method
-      register: ipv6_method
-      ignore_errors: yes
-      changed_when: false
-
-    - name: "Assert that ipv6.method disabled is configured correctly"
-      assert:
-        that:
-          - "'disabled' in ipv6_method.stdout"
-        msg: "ipv6.method disabled is configured incorrectly"
+        type: veth
+        interface: ethtest0
 
 - import_playbook: down_profile+delete_interface.yml
   vars:
+    interface: ethtest0
     profile: "{{ interface }}"
 # FIXME: assert profile/device down
 - import_playbook: remove_profile.yml
   vars:
+    interface: ethtest0
     profile: "{{ interface }}"
 - name: Assert device and profile are absent
   hosts: all
   tasks:
     - include_tasks: tasks/assert_profile_absent.yml
       vars:
+        interface: ethtest0
         profile: "{{ interface }}"
     - include_tasks: tasks/assert_device_absent.yml
 ...

--- a/tests/playbooks/tests_route_table.yml
+++ b/tests/playbooks/tests_route_table.yml
@@ -4,147 +4,149 @@
 
 - name: Test configuring ethernet devices
   hosts: all
-  vars:
-    type: veth
-    interface: ethtest0
-
 
   tasks:
-    - name: "set type={{ type }} and interface={{ interface }}"
-      set_fact:
-        type: "{{ type }}"
-        interface: "{{ interface }}"
-    - include_tasks: tasks/show_interfaces.yml
-    - include_tasks: tasks/manage_test_interface.yml
+    - block:
+        - name: "set type={{ type }} and interface={{ interface }}"
+          set_fact:
+            type: "{{ type }}"
+            interface: "{{ interface }}"
+        - include_tasks: tasks/show_interfaces.yml
+        - include_tasks: tasks/manage_test_interface.yml
+          vars:
+            state: present
+        - include_tasks: tasks/assert_device_present.yml
+
+        - name: Configure connection profile and specify the numeric table in
+            static routes
+          import_role:
+            name: linux-system-roles.network
+          vars:
+            network_connections:
+              - name: "{{ interface }}"
+                interface_name: "{{ interface }}"
+                state: up
+                type: ethernet
+                autoconnect: yes
+                ip:
+                  dhcp4: no
+                  address:
+                    - 198.51.100.3/26
+                  route:
+                    - network: 198.51.100.128
+                      prefix: 26
+                      gateway: 198.51.100.1
+                      metric: 2
+                      table: 30400
+                    - network: 198.51.100.64
+                      prefix: 26
+                      gateway: 198.51.100.6
+                      metric: 4
+                      table: 30200
+
+        - name: Get the routes from the route table 30200
+          command: ip route show table 30200
+          register: route_table_30200
+          ignore_errors: yes
+          changed_when: false
+
+        - name: Get the routes from the route table 30400
+          command: ip route show table 30400
+          register: route_table_30400
+          ignore_errors: yes
+          changed_when: false
+
+        - name: Assert that the route table 30200 contains the specified route
+          assert:
+            that:
+              - route_table_30200.stdout is search("198.51.100.64/26 via
+                198.51.100.6 dev ethtest0 proto static metric 4")
+            msg: "the route table 30200 does not exist or does not contain the
+              specified route"
+
+        - name: Assert that the route table 30400 contains the specified route
+          assert:
+            that:
+              - route_table_30400.stdout is search("198.51.100.128/26 via
+                198.51.100.1 dev ethtest0 proto static metric 2")
+            msg: "the route table 30400 does not exist or does not contain the
+              specified route"
+
+        - name: Create a dedicated test file in `/etc/iproute2/rt_tables.d/` and
+                add a new routing table
+          lineinfile:
+            path: /etc/iproute2/rt_tables.d/table.conf
+            line: "200 custom"
+            mode: "0644"
+            create: yes
+
+        - name: Reconfigure connection profile and specify the named table in
+            static routes
+          import_role:
+            name: linux-system-roles.network
+          vars:
+            network_connections:
+              - name: "{{ interface }}"
+                interface_name: "{{ interface }}"
+                state: up
+                type: ethernet
+                autoconnect: yes
+                ip:
+                  dhcp4: no
+                  address:
+                    - 198.51.100.3/26
+                  route:
+                    - network: 198.51.100.128
+                      prefix: 26
+                      gateway: 198.51.100.1
+                      metric: 2
+                      table: custom
+                    - network: 198.51.100.64
+                      prefix: 26
+                      gateway: 198.51.100.6
+                      metric: 4
+                      table: custom
+
+        - name: Get the routes from the named route table 'custom'
+          command: ip route show table custom
+          register: route_table_custom
+          ignore_errors: yes
+          changed_when: false
+
+        - name: Assert that the named route table 'custom' contains the
+            specified route
+          assert:
+            that:
+              - route_table_custom.stdout is search("198.51.100.128/26 via
+                198.51.100.1 dev ethtest0 proto static metric 2")
+              - route_table_custom.stdout is search("198.51.100.64/26 via
+                198.51.100.6 dev ethtest0 proto static metric 4")
+            msg: "the named route table 'custom' does not exist or does not
+              contain the specified route"
+
+        - name: Remove the dedicated test file in `/etc/iproute2/rt_tables.d/`
+          file:
+            state: absent
+            path: /etc/iproute2/rt_tables.d/table.conf
       vars:
-        state: present
-    - include_tasks: tasks/assert_device_present.yml
-
-    - name: Configure connection profile and specify the numeric table in
-        static routes
-      import_role:
-        name: linux-system-roles.network
-      vars:
-        network_connections:
-          - name: "{{ interface }}"
-            interface_name: "{{ interface }}"
-            state: up
-            type: ethernet
-            autoconnect: yes
-            ip:
-              dhcp4: no
-              address:
-                - 198.51.100.3/26
-              route:
-                - network: 198.51.100.128
-                  prefix: 26
-                  gateway: 198.51.100.1
-                  metric: 2
-                  table: 30400
-                - network: 198.51.100.64
-                  prefix: 26
-                  gateway: 198.51.100.6
-                  metric: 4
-                  table: 30200
-
-    - name: Get the routes from the route table 30200
-      command: ip route show table 30200
-      register: route_table_30200
-      ignore_errors: yes
-      changed_when: false
-
-    - name: Get the routes from the route table 30400
-      command: ip route show table 30400
-      register: route_table_30400
-      ignore_errors: yes
-      changed_when: false
-
-    - name: Assert that the route table 30200 contains the specified route
-      assert:
-        that:
-          - route_table_30200.stdout is search("198.51.100.64/26 via
-            198.51.100.6 dev ethtest0 proto static metric 4")
-        msg: "the route table 30200 does not exist or does not contain the
-          specified route"
-
-
-    - name: Assert that the route table 30400 contains the specified route
-      assert:
-        that:
-          - route_table_30400.stdout is search("198.51.100.128/26 via
-            198.51.100.1 dev ethtest0 proto static metric 2")
-        msg: "the route table 30400 does not exist or does not contain the
-          specified route"
-
-    - name: Create a dedicated test file in `/etc/iproute2/rt_tables.d/` and
-            add a new routing table
-      lineinfile:
-        path: /etc/iproute2/rt_tables.d/table.conf
-        line: "200 custom"
-        mode: "0644"
-        create: yes
-
-    - name: Reconfigure connection profile and specify the named table in
-        static routes
-      import_role:
-        name: linux-system-roles.network
-      vars:
-        network_connections:
-          - name: "{{ interface }}"
-            interface_name: "{{ interface }}"
-            state: up
-            type: ethernet
-            autoconnect: yes
-            ip:
-              dhcp4: no
-              address:
-                - 198.51.100.3/26
-              route:
-                - network: 198.51.100.128
-                  prefix: 26
-                  gateway: 198.51.100.1
-                  metric: 2
-                  table: custom
-                - network: 198.51.100.64
-                  prefix: 26
-                  gateway: 198.51.100.6
-                  metric: 4
-                  table: custom
-
-    - name: Get the routes from the named route table 'custom'
-      command: ip route show table custom
-      register: route_table_custom
-      ignore_errors: yes
-      changed_when: false
-
-    - name: Assert that the named route table 'custom' contains the
-        specified route
-      assert:
-        that:
-          - route_table_custom.stdout is search("198.51.100.128/26 via
-            198.51.100.1 dev ethtest0 proto static metric 2")
-          - route_table_custom.stdout is search("198.51.100.64/26 via
-            198.51.100.6 dev ethtest0 proto static metric 4")
-        msg: "the named route table 'custom' does not exist or does not contain
-          the specified route"
-
-    - name: Remove the dedicated test file in `/etc/iproute2/rt_tables.d/`
-      file:
-        state: absent
-        path: /etc/iproute2/rt_tables.d/table.conf
+        type: veth
+        interface: ethtest0
 
 - import_playbook: down_profile+delete_interface.yml
   vars:
+    interface: ethtest0
     profile: "{{ interface }}"
 # FIXME: assert profile/device down
 - import_playbook: remove_profile.yml
   vars:
+    interface: ethtest0
     profile: "{{ interface }}"
 - name: Assert device and profile are absent
   hosts: all
   tasks:
     - include_tasks: tasks/assert_profile_absent.yml
       vars:
+        interface: ethtest0
         profile: "{{ interface }}"
     - include_tasks: tasks/assert_device_absent.yml
 ...


### PR DESCRIPTION
This is part of the effort to allow CI tests run in the serialized
manner on one VM for shortening the duration of the CI tests. If
set_fact is used, a value of "interface" in a test is visible to
the next test, which could make the next test fail.

Plus this commit adds a network restart code in bond_deprecated.
After running bond_deprecated test case, the network is down.
Unless it's restarted the following test fails in the necessary
package download.