### PR TITLE
ipv6_disabled: Skip the tests on RHEL-7 or CentOS-7

### DIFF
--- a/tests/playbooks/tests_ipv6_dns_search.yml
+++ b/tests/playbooks/tests_ipv6_dns_search.yml
@@ -124,12 +124,14 @@
                 state: up
           ignore_errors: true  # noqa ignore-errors
           changed_when: false
+          when: ansible_distribution_major_version | int > 7
 
         - name: Assert that reconfiguring network connection is failed
           assert:
             that:
               - __network_connections_result.failed
             msg: reconfiguring network connection is not failed
+          when: ansible_distribution_major_version | int > 7
 
         - name: Assert that configuring DNS search setting is not allowed when
             both IPv4 and IPv6 are disabled
@@ -141,6 +143,7 @@
             msg: Reconfiguring network connection is not failed with the error
               "Setting 'dns_search' or 'dns_options' is not allowed when both
               IPv4 and IPv6 are disabled."
+          when: ansible_distribution_major_version | int > 7
 
       always:
         - block:


### PR DESCRIPTION
ip.ipv6_disabled is not supported by the running version of
NetworkManager when testing on RHEL-7 or CentOS-7, therefore, skip the
tests on RHEL-7 or CentOS-7.

Signed-off-by: Wen Liang <liangwen12year@gmail.com>