### PR TITLE
no gather facts setup snapshot

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -121,3 +121,11 @@ network_packages: "{{
     __network_provider_setup[network_provider]['packages'] }}"
 network_service_name: "{{
     __network_provider_setup[network_provider]['service_name'] }}"
+
+# ansible_facts required by the role
+__network_required_facts:
+  - distribution
+  - distribution_major_version
+  - distribution_version
+  - os_family
+  - python

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # get service facts, used in defaults/main.yml
 ---
+- name: Ensure ansible_facts used by role
+  setup:
+    gather_subset: min
+  when: not ansible_facts.keys() | list |
+    intersect(__network_required_facts) == __network_required_facts
+  no_log: true
+
 - name: Check which services are running
   service_facts:
   no_log: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,20 +2,7 @@
 # get service facts, used in defaults/main.yml
 ---
 - name: Ensure ansible_facts used by role
-  setup:
-    gather_subset: min
-  when: not ansible_facts.keys() | list |
-    intersect(__network_required_facts) == __network_required_facts
-  no_log: true
-
-- name: Check which services are running
-  service_facts:
-  no_log: true
-
-# needed for ansible_facts.packages
-- name: Check which packages are installed
-  package_facts:
-  no_log: true
+  include_tasks: tasks/set_facts.yml
 
 - name: Print network provider
   debug:

--- a/tasks/set_facts.yml
+++ b/tasks/set_facts.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: BSD-3-Clause
+---
+- name: Ensure ansible_facts used by role are present
+  setup:
+    gather_subset: min
+  when: not ansible_facts.keys() | list |
+    intersect(__network_required_facts) == __network_required_facts
+  no_log: true
+
+- name: Check which services are running
+  service_facts:
+  no_log: true
+
+# needed for ansible_facts.packages
+- name: Check which packages are installed
+  package_facts:
+  no_log: true

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -1,0 +1,12 @@
+- hosts: all
+  tasks:
+    - name: Set facts used by role
+      include_role:
+        name: linux-system-roles.network
+        tasks_from: set_facts.yml
+        public: true
+
+    - name: Install test packages
+      package:
+        name: "{{ network_packages }}"
+        state: present

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -2,6 +2,7 @@
 ---
 - name: Test executing the role with default parameters
   hosts: all
+  gather_facts: false
   roles:
     - linux-system-roles.network
   tasks:


### PR DESCRIPTION
- support playbooks which use gather_facts: false
- add setup-snapshot.yml used to prepare testing snapshots
