### PR TITLE
infiniband: Fix the bug of wrongly checking whether the device exists

### DIFF
--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -44,6 +44,7 @@ from ansible.module_utils.network_lsr.myerror import MyError  # noqa:E501
 
 from ansible.module_utils.network_lsr.argument_validator import (  # noqa:E501
     ArgUtil,
+    ArgValidator_DictInfiniband,
     ArgValidator_ListConnections,
     ValidationError,
 )
@@ -348,7 +349,10 @@ class IfcfgUtil:
                 if (connection["infiniband"]["transport_mode"] == "connected")
                 else "no"
             )
-            if connection["infiniband"]["p_key"] != -1:
+            if (
+                connection["infiniband"]["p_key"]
+                != ArgValidator_DictInfiniband.DEFAULT_PKEY
+            ):
                 ifcfg["PKEY"] = "yes"
                 ifcfg["PKEY_ID"] = str(connection["infiniband"]["p_key"])
                 if connection["parent"]:
@@ -846,7 +850,10 @@ class NMUtil:
                 NM.SETTING_INFINIBAND_TRANSPORT_MODE,
                 connection["infiniband"]["transport_mode"],
             )
-            if connection["infiniband"]["p_key"] != -1:
+            if (
+                connection["infiniband"]["p_key"]
+                != ArgValidator_DictInfiniband.DEFAULT_PKEY
+            ):
                 s_infiniband.set_property(
                     NM.SETTING_INFINIBAND_P_KEY, connection["infiniband"]["p_key"]
                 )
@@ -2012,7 +2019,10 @@ class Cmd(object):
                                 "interface exists" % (connection["interface_name"]),
                             )
                         elif connection["type"] == "infiniband":
-                            if connection["infiniband"]["p_key"] != -1:
+                            if (
+                                connection["infiniband"]["p_key"]
+                                == ArgValidator_DictInfiniband.DEFAULT_PKEY
+                            ):
                                 self.log_fatal(
                                     idx,
                                     "profile specifies interface_name '%s' but no such "

--- a/module_utils/network_lsr/argument_validator.py
+++ b/module_utils/network_lsr/argument_validator.py
@@ -1553,6 +1553,8 @@ class ArgValidator_DictBond(ArgValidatorDict):
 
 
 class ArgValidator_DictInfiniband(ArgValidatorDict):
+    DEFAULT_PKEY = -1
+
     def __init__(self):
         ArgValidatorDict.__init__(
             self,
@@ -1561,13 +1563,21 @@ class ArgValidator_DictInfiniband(ArgValidatorDict):
                 ArgValidatorStr(
                     "transport_mode", enum_values=["datagram", "connected"]
                 ),
-                ArgValidatorNum("p_key", val_min=-1, val_max=0xFFFF, default_value=-1),
+                ArgValidatorNum(
+                    "p_key",
+                    val_min=-1,
+                    val_max=0xFFFF,
+                    default_value=ArgValidator_DictInfiniband.DEFAULT_PKEY,
+                ),
             ],
             default_value=ArgValidator.MISSING,
         )
 
     def get_default_infiniband(self):
-        return {"transport_mode": "datagram", "p_key": -1}
+        return {
+            "transport_mode": "datagram",
+            "p_key": ArgValidator_DictInfiniband.DEFAULT_PKEY,
+        }
 
 
 class ArgValidator_DictVlan(ArgValidatorDict):

--- a/tests/playbooks/tests_bond_options.yml
+++ b/tests/playbooks/tests_bond_options.yml
@@ -128,11 +128,6 @@
                   arp_ip_target: 192.0.2.128
                   arp_validate: none
                   primary: "{{ dhcp_interface1 }}"
-              # add an infiniband port to the bond
-              - name: ib0
-                type: infiniband
-                interface_name: ib0
-                controller: "{{ controller_profile }}"
         - command: cat
             /sys/class/net/{{ controller_device }}/bonding/'{{ item.key }}'
           name: "** TEST check bond settings"
@@ -157,14 +152,6 @@
           until: "'2001' in result.stdout"
           retries: 20
           delay: 2
-
-        - command: nmcli -f '{{ item.key }}' connection show ib0
-          name: "** TEST check the infiniband port profile"
-          register: result
-          until: "'{{ item.value }}' in result.stdout"
-          loop:
-            - { key: 'connection.interface-name', value: 'ib0'}
-            - { key: 'connection.type', value: 'infiniband'}
 
       always:
         - block:


### PR DESCRIPTION
When activating the connection on the virtual infiniband device, the
device does not need to be present upfront. The previous implementation
is wrong which validating the presence of virtual infiniband device
upfront, as a result, the users have to create the virtual infiniband
device manually in the target system in order to activating the
connection on the virtual infiniband device through the role. This is
an actual bug, the exception raised when the users do not
pre-configured such a virtual infiniband device. To address the
problem, fix the bug of wrongly checking whether the device exists.

Signed-off-by: Wen Liang <liangwen12year@gmail.com>