### PR TITLE
[citest skip] bump tox-lsr version to 2.11.0; remove py37; add py310

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,7 +4,7 @@ on:  # yamllint disable-line rule:truthy
   - pull_request
   - push
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.10.1"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.11.0"
   LSR_ANSIBLE_TEST_DOCKER: "true"
   LSR_ANSIBLES: 'ansible==2.9.*'
   LSR_MSCENARIOS: default
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pyver: ['2.7', '3.6', '3.8', '3.9']
+        pyver: ['2.7', '3.6', '3.8', '3.9', '3.10']
     steps:
       - name: checkout PR
         uses: actions/checkout@v2
@@ -41,6 +41,7 @@ jobs:
           36) toxenvs="${toxenvs},coveralls,ensure_provider_tests,black,yamllint" ;;
           38) toxenvs="${toxenvs},coveralls,ansible-lint,ansible-plugin-scan,collection,ansible-test" ;;
           39) toxenvs="${toxenvs},coveralls,ansible-managed-var-comment" ;;
+          310) toxenvs="${toxenvs},coveralls" ;;
           esac
           TOXENV="$toxenvs" lsr_ci_runtox
   python-26:


### PR DESCRIPTION
tox-lsr version 2.11.0 has support for collection-requirements.yml,
runqemu improvements, and support for python 3.10

python 3.7 is not used on any supported platform, so remove it