### PR TITLE
To support running the tests in the serialized fashion, assign different

### DIFF
--- a/tests/playbooks/tests_bond_removal.yml
+++ b/tests/playbooks/tests_bond_removal.yml
@@ -3,7 +3,7 @@
 - hosts: all
   vars:
     controller_profile: bond0
-    controller_device: nm-bond
+    controller_device: nm-bond-removal
     port1_profile: bond0.0
     dhcp_interface1: test1
     port2_profile: bond0.1
@@ -203,7 +203,7 @@
           when: network_provider == "nm"
 
         - name: Get the controller device details
-          command: ip -d a s nm-bond
+          command: ip -d a s {{ controller_device }}
           register: controller_state
           ignore_errors: yes
           changed_when: false


### PR DESCRIPTION
device names.

If the controller device name is shared between tests_bond_options_nm.yml
and tests_bond_removal_*.yml, the removal tests fail with:
  Error: Connection activation failed:
    No suitable device found for this connection

Note: "serialized" means running the tests on the same VM. Although the previous test playbook `tests_bond_options.yml` removes `nm-bond` in the cleanup task with `ip link del nm-bond`, the following test `tests_bond_removal_initscripts.yml` fails as follows.

Complete failed output from `tests_bond_removal_initscripts.yml` (**prior to applying this patch, so it's still using "nm-bond" for the device name**):
```
TASK [rhel-system-roles.network : Configure networking connection profiles] ****
task path: /usr/share/ansible/roles/rhel-system-roles.network/tasks/main.yml:75
Wednesday 11 May 2022  11:50:36 -0400 (0:00:00.520)       0:00:16.656 *********
"'
[WARNING]: [012] <error> #0, state:up persistent_state:present, 'bond0': call 'ifup bond0' failed with exit status 1
fatal: [/tmp/tmp.Qg8GGc0RZE/image.qcow2.snap]: FAILED! => {
    "_invocation": {
        "module_args": {
            "__debug_flags": "",
            "__header": "#
            # Ansible managed
            #",
            "connections": [
                {
                    "bond": {
                        "miimon": 110,
                        "mode": "active-backup"
                    },
                    "interface_name": "nm-bond",
                    "name": "bond0",
                    "state": "up",
                    "type": "bond"
                },
                {
                    "controller": "bond0",
                    "interface_name": "test1",
                    "name": "bond0.0",
                    "state": "up",
                    "type": "ethernet"
                },
                {
                    "controller": "bond0",
                    "interface_name": "test2",
                    "name": "bond0.1",
                    "state": "up",
                    "type": "ethernet"
                }
            ],
            "force_state_change": false,
            "ignore_errors": false,
            "provider": "initscripts"
        }
    },
    "changed": true
}

STDERR:
[007] <info>  #0, state:up persistent_state:present, 'bond0': add ifcfg-rh profile 'bond0'
[008] <info>  #1, state:up persistent_state:present, 'bond0.0': add ifcfg-rh profile 'bond0.0'
[009] <info>  #2, state:up persistent_state:present, 'bond0.1': add ifcfg-rh profile 'bond0.1'
[010] <info>  #0, state:up persistent_state:present, 'bond0': up connection bond0 (not-active)
[011] <info>  #0, state:up persistent_state:present, 'bond0': call 'ifup bond0': rc=1, out='b'WARN      : [/etc/sysconfig/network-scripts/ifup-eth] Unable to start slave device ifcfg-ib0 for master nm-bond.

Determining IP information for nm-bond... failed.
'', err='b"WARN      : [ifup] You are using 'ifup' script provided by 'network-scripts', which are now deprecated.
WARN      : [ifup] 'network-scripts' will be removed in one of the next major releases of RHEL.
WARN      : [ifup] It is advised to switch to 'NetworkManager' instead - it provides 'ifup/ifdown' scripts as well.
WARN      : [ifup] You are using 'ifup' script provided by 'network-scripts', which are now deprecated.
WARN      : [ifup] 'network-scripts' will be removed in one of the next major releases of RHEL.
WARN      : [ifup] It is advised to switch to 'NetworkManager' instead - it provides 'ifup/ifdown' scripts as well.
WARN      : [ifup] You are using 'ifup' script provided by 'network-scripts', which are now deprecated.
WARN      : [ifup] 'network-scripts' will be removed in one of the next major releases of RHEL.
WARN      : [ifup] It is advised to switch to 'NetworkManager' instead - it provides 'ifup/ifdown' scripts as well.
WARN      : [ifup] You are using 'ifup' script provided by 'network-scripts', which are now deprecated.
WARN      : [ifup] 'network-scripts' will be removed in one of the next major releases of RHEL.
WARN      : [ifup] It is advised to switch to 'NetworkManager' instead - it provides 'ifup/ifdown' scripts as well.
Error: Connection activation failed: No suitable device found for this connection (device eth0 not available because profile is not compatible with device (mismatching interface name)).
dhclient(23010) is already running - exiting. 

This version of ISC DHCP is based on the release available
on ftp.isc.org. Features have been added and other changes
have been made to the base software release in order to make
it work better with this distribution.

Please report issues with this software via: 
https://bugzilla.redhat.com/

exiting.
"'
[012] <error> #0, state:up persistent_state:present, 'bond0': call 'ifup bond0' failed with exit status 1

MSG:
error: call 'ifup bond0' failed with exit status 1
```

