### PR TITLE
change include to include_tasks

### DIFF
--- a/tests/tasks/assert_device_absent.yml
+++ b/tests/tasks/assert_device_absent.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- include: get_interface_stat.yml
+- include_tasks: get_interface_stat.yml
 - name: "assert that interface {{ interface }} is absent"
   assert:
     that: not interface_stat.stat.exists

--- a/tests/tasks/assert_device_present.yml
+++ b/tests/tasks/assert_device_present.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- include: get_interface_stat.yml
+- include_tasks: get_interface_stat.yml
 - name: "assert that interface {{ interface }} is present"
   assert:
     that: interface_stat.stat.exists

--- a/tests/tasks/assert_profile_absent.yml
+++ b/tests/tasks/assert_profile_absent.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- include: get_profile_stat.yml
+- include_tasks: get_profile_stat.yml
 - name: "assert that profile '{{ profile }}' is absent"
   assert:
     that: not lsr_net_profile_exists

--- a/tests/tasks/assert_profile_present.yml
+++ b/tests/tasks/assert_profile_present.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- include: get_profile_stat.yml
+- include_tasks: get_profile_stat.yml
 - name: "assert that profile '{{ profile }}' is present"
   assert:
     that: lsr_net_profile_exists

--- a/tests/tasks/manage_test_interface.yml
+++ b/tests/tasks/manage_test_interface.yml
@@ -10,7 +10,7 @@
     msg: "type needs to be dummy, tap or veth, not '{{ type }}'"
   when: type not in ["dummy", "tap", "veth"]
 
-- include: show_interfaces.yml
+- include_tasks: show_interfaces.yml
 
 - name: Install iproute
   package:

--- a/tests/tasks/show_interfaces.yml
+++ b/tests/tasks/show_interfaces.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- include: get_current_interfaces.yml
+- include_tasks: get_current_interfaces.yml
 - name: Show current_interfaces
   debug:
     msg: "current_interfaces: {{ current_interfaces }}"


### PR DESCRIPTION
The keyword `include:` is deprecated in favor of
`include_tasks:`.
See https://docs.ansible.com/ansible/latest/collections/ansible/builtin/include_module.html

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
