### PR TITLE
bond: Test arp_all_targets only when arp_interval is enabled

### DIFF
--- a/examples/bond_options.yml
+++ b/examples/bond_options.yml
@@ -20,7 +20,6 @@
           ad_select: stable
           ad_user_port_key: 1023
           all_ports_active: True
-          arp_all_targets: all
           downdelay: 0
           lacp_rate: slow
           lp_interval: 128

--- a/module_utils/network_lsr/argument_validator.py
+++ b/module_utils/network_lsr/argument_validator.py
@@ -1494,7 +1494,7 @@ class ArgValidator_DictBond(ArgValidatorDict):
                 name,
                 "the bond option downdelay or updelay is only valid with miimon enabled",
             )
-        if result["peer_notif_delay"] is not None:
+        if result["peer_notif_delay"]:
             if not result["miimon"] or result["peer_notif_delay"] % result["miimon"]:
                 raise ValidationError(
                     name,

--- a/tests/playbooks/tests_bond_options.yml
+++ b/tests/playbooks/tests_bond_options.yml
@@ -40,7 +40,6 @@
                   ad_select: stable
                   ad_user_port_key: 1023
                   all_ports_active: True
-                  arp_all_targets: all
                   downdelay: 0
                   lacp_rate: slow
                   lp_interval: 128
@@ -88,7 +87,6 @@
             - { key: 'ad_select', value: 'stable'}
             - { key: 'ad_user_port_key', value: '1023'}
             - { key: 'all_slaves_active', value: '1'}
-            - { key: 'arp_all_targets', value: 'all'}
             - { key: 'downdelay', value: '0'}
             - { key: 'lacp_rate', value: 'slow'}
             - { key: 'lp_interval', value: '128'}

--- a/tests/playbooks/tests_bond_options.yml
+++ b/tests/playbooks/tests_bond_options.yml
@@ -126,6 +126,18 @@
                   arp_ip_target: 192.0.2.128
                   arp_validate: none
                   primary: "{{ dhcp_interface1 }}"
+              # add an ethernet to the bond
+              - name: "{{ port1_profile }}"
+                state: up
+                type: ethernet
+                interface_name: "{{ dhcp_interface1 }}"
+                controller: "{{ controller_profile }}"
+              # add a second ethernet to the bond
+              - name: "{{ port2_profile }}"
+                state: up
+                type: ethernet
+                interface_name: "{{ dhcp_interface2 }}"
+                controller: "{{ controller_profile }}"
         - command: cat
             /sys/class/net/{{ controller_device }}/bonding/'{{ item.key }}'
           name: "** TEST check bond settings"


### PR DESCRIPTION
Kernel allows to set `arp_all_targets` when `arp_interval` is disabled (disable ARP monitoring). But `arp_all_targets` specifies the quantity of `arp_ip_targets` that must be reachable in order for the ARP monitor to consider a slave as being up. It makes more sense to set the `arp_all_targets` while enabling the `arp_interval`.

Signed-off-by: Wen Liang <liangwen12year@gmail.com>