### PR TITLE
Add support for __network_test_flags to workaround CI problems

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -323,6 +323,17 @@ ansible-playbook --skip-tags tests::cleanup \
     -i testhost, tests/playbooks/tests_802_1x.yml
 ```
 
+### Test Hacks
+
+There is a parameter `__network_test_flags` which is a `dict` and can be used to
+pass values required by the test infrastructure into the module.  For example:
+Some of the `initscripts` tests create default routes, that, on some systems,
+will override the "default" default route and cause an interruption in network
+connectivity. This will cause Ansible to hang as `ssh` requires a network
+connection.  The test flags are used to pass in a `metric` parameter which will
+ensure that the test route created is given a lower priority than the "default"
+default route.
+
 ### NetworkManager Documentation
 
 - [NM 1.0](https://lazka.github.io/pgi-docs/#NM-1.0), it contains a full explanation

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -121,6 +121,7 @@
     connections: "{{ network_connections | default([]) }}"
     __debug_flags: "{{ __network_debug_flags | default(omit) }}"
     __header: "{{ __lsr_ansible_managed }}"
+    __test_flags: "{{ __network_test_flags | default(omit) }}"
   vars:
     __lsr_ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"
   register: __network_connections_result

--- a/tests/playbooks/tests_auto_gateway.yml
+++ b/tests/playbooks/tests_auto_gateway.yml
@@ -31,6 +31,8 @@
                 - "203.0.113.2/24"
               gateway6: "2001:db8::1"
               gateway4: "203.0.113.1"
+        __network_test_flags:
+          metric: 4294967295
     - include_tasks: tasks/assert_device_present.yml
     - include_tasks: tasks/assert_profile_present.yml
       vars:


### PR DESCRIPTION
On some CI systems the tests that create routes can create them in such
a way that they override the "default" default routes, interrupting
network connectivity and causing Ansible to hang.  The parameter
`__network_test_flags` gives network role developers a way to ensure
that the newly created route is given a lower priority and does not
override the "default" default route.  A `dict` was chosen as the type
of this variable so that it could be easily extended in the future for
future use cases.
