### PR TITLE
add ip.route_metric4: 65535 to failing bond tests

### DIFF
--- a/tests/playbooks/tests_auto_gateway.yml
+++ b/tests/playbooks/tests_auto_gateway.yml
@@ -34,7 +34,7 @@
               # change the default route metric to higher value so that it will
               # not take precedence over other routes or not ignore other
               # routes
-              route_metric4: 4294967295
+              route_metric4: 65535
     - include_tasks: tasks/assert_device_present.yml
     - include_tasks: tasks/assert_profile_present.yml
       vars:

--- a/tests/playbooks/tests_bond.yml
+++ b/tests/playbooks/tests_bond.yml
@@ -40,6 +40,8 @@
                 bond:
                   mode: active-backup
                   miimon: 110
+                ip:
+                  route_metric4: 65535
               # add an ethernet to the bond
               - name: "{{ port1_profile }}"
                 state: up

--- a/tests/playbooks/tests_bond_deprecated.yml
+++ b/tests/playbooks/tests_bond_deprecated.yml
@@ -36,6 +36,8 @@
                 bond:
                   mode: active-backup
                   miimon: 110
+                ip:
+                  route_metric4: 65535
               # add an ethernet to the bond
               - name: "{{ port1_profile }}"
                 state: up

--- a/tests/playbooks/tests_bond_options.yml
+++ b/tests/playbooks/tests_bond_options.yml
@@ -51,6 +51,8 @@
                   updelay: 0
                   use_carrier: True
                   xmit_hash_policy: encap2+3
+                ip:
+                  route_metric4: 65535
 
               # add an ethernet to the bond
               - name: "{{ port1_profile }}"
@@ -126,6 +128,8 @@
                   arp_ip_target: 192.0.2.128
                   arp_validate: none
                   primary: "{{ dhcp_interface1 }}"
+                ip:
+                  route_metric4: 65535
               # add an ethernet to the bond
               - name: "{{ port1_profile }}"
                 state: up

--- a/tests/playbooks/tests_bond_removal.yml
+++ b/tests/playbooks/tests_bond_removal.yml
@@ -40,6 +40,8 @@
                 bond:
                   mode: active-backup
                   miimon: 110
+                ip:
+                  route_metric4: 65535
               # add an ethernet to the bond
               - name: "{{ port1_profile }}"
                 state: up
@@ -161,6 +163,8 @@
                 bond:
                   mode: active-backup
                   miimon: 110
+                ip:
+                  route_metric4: 65535
               # add an ethernet to the bond
               - name: "{{ port1_profile }}"
                 state: up


### PR DESCRIPTION
When creating a bond, the bond also creates a default route with a
default metric of 0.  This causes test failures on CI systems as
it overrides the system default route.  Use the new `ip.route_metric4`
parameter to set a high metric value so as not to override the
default system route.
Some systems cannot use a metric value of 32 bit unsigned int max value.  To ensure
the broadest possible support, use a metric value of 16 bit signed int max value,
which should be high enough to ensure the routes always have the lowest priority.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
