### PR TITLE
ansible-lint 6.x updates

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,6 @@
 ---
 skip_list:
+  - role-name
   - fqcn-builtins
 warn_list:
   - load-failure  # allow include_tasks with tasks/ directory

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,10 +1,19 @@
 ---
-exclude_paths:
-  - tests/
-  - .github/
-  - .ansible-lint
 skip_list:
-  - role-name
-  - fqcn
+  - fqcn-builtins
 warn_list:
   - load-failure  # allow include_tasks with tasks/ directory
+exclude_paths:
+  - tests/
+  - tests/roles/
+  - .github/
+  - examples/roles/
+kinds:
+  - playbook: "**/tests/tests_*.yml"
+  - playbook: "**/tests/setup-snapshot.yml"
+  - tasks: "**/tests/*.yml"
+  - playbook: "**/tests/playbooks/*.yml"
+  - tasks: "**/tests/tasks/*.yml"
+  - tasks: "**/tests/tasks/*/*.yml"
+  - vars: "**/tests/vars/*.yml"
+  - playbook: "**/examples/*.yml"

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 ---
-extends: yamllint_defaults.yml
+extends: default
 # possible customizations over the base yamllint config
 # skip the yaml files in the /tests/ directory
 # NOTE: If you want to customize `ignore` you'll have to
@@ -19,7 +19,6 @@ ignore: |
   tests/roles/
   .tox/
 rules:
-  truthy: disable
   line-length:
     ignore: |
       /tests/tasks/setup_mock_wifi_wpa3_owe.yml

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -19,6 +19,8 @@ ignore: |
   tests/roles/
   .tox/
 rules:
+  truthy: disable
+  document-start: disable
   line-length:
     ignore: |
       /tests/tasks/setup_mock_wifi_wpa3_owe.yml

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -19,6 +19,12 @@ ignore: |
   tests/roles/
   .tox/
 rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
   truthy: disable
   document-start: disable
   line-length:

--- a/examples/bond_options.yml
+++ b/examples/bond_options.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: network-test
+- name: Manage bond options
+  hosts: network-test
   vars:
     network_connections:
       # Specify the bond profile

--- a/examples/bond_simple.yml
+++ b/examples/bond_simple.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: network-test
+- name: Manage bond connection
+  hosts: network-test
   vars:
     network_connections:
       # Specify the bond profile

--- a/examples/bond_with_vlan.yml
+++ b/examples/bond_with_vlan.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: network-test
+- name: Manage bond with VLAN
+  hosts: network-test
   vars:
     network_connections:
       # Create a bond profile, which is the parent of VLAN.

--- a/examples/bridge_with_vlan.yml
+++ b/examples/bridge_with_vlan.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: network-test
+- name: Manage bridge with VLAN
+  hosts: network-test
   vars:
     network_connections:
       # Create a bridge profile, which is the parent of VLAN.

--- a/examples/cloned_mac.yml
+++ b/examples/cloned_mac.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: network-test
+- name: Manage cloned MAC
+  hosts: network-test
   vars:
     network_connections:
       # specify the bond profile

--- a/examples/dummy_simple.yml
+++ b/examples/dummy_simple.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: all
+- name: Example of profile management
+  hosts: all
   vars:
     network_connections:
       # Specify the dummy profile

--- a/examples/eth_dns_support.yml
+++ b/examples/eth_dns_support.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: all
+- name: Manage DNS settings
+  hosts: all
   vars:
     network_connections:
       - name: eth0

--- a/examples/eth_simple_auto.yml
+++ b/examples/eth_simple_auto.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: network-test
+- name: Manage autoconnect
+  hosts: network-test
   vars:
     network_connections:
       # Create one ethernet profile and activate it.

--- a/examples/eth_with_802_1x.yml
+++ b/examples/eth_with_802_1x.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: network-test
+- name: Manage 802.1x with certs
+  hosts: network-test
   vars:
     network_connections:
       - name: eth0
@@ -22,6 +23,7 @@
       copy:
         src: "{{ item }}"
         dest: /etc/pki/tls/{{ item }}
+        mode: 0600
       with_items:
         - client.key
         - client.pem

--- a/examples/eth_with_vlan.yml
+++ b/examples/eth_with_vlan.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: network-test
+- name: Manage ethernet with VLAN
+  hosts: network-test
   vars:
     network_connections:
       # Create a profile for the underlying device of the VLAN.

--- a/examples/ethtool_coalesce.yml
+++ b/examples/ethtool_coalesce.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: all
+- name: Manage ethernet coalesce
+  hosts: all
   tasks:
     - name: Configure ethernet coalesce
       include_role:

--- a/examples/ethtool_features.yml
+++ b/examples/ethtool_features.yml
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: all
+- name: Manage ethernet parameters
+  hosts: all
   tasks:
-    - name: Configure ethernet paramters
+    - name: Configure ethernet parameters
       include_role:
         name: linux-system-roles.network
       vars:

--- a/examples/ethtool_features_default.yml
+++ b/examples/ethtool_features_default.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: all
+- name: Manage ethernet features
+  hosts: all
   tasks:
     - name: Configure ethernet features
       include_role:

--- a/examples/ethtool_ring.yml
+++ b/examples/ethtool_ring.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: all
+- name: Manage ethtool ring
+  hosts: all
   tasks:
     - name: Configure ring parameters
       include_role:

--- a/examples/infiniband.yml
+++ b/examples/infiniband.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: network-test
+- name: Manage inifiniband example
+  hosts: network-test
   vars:
     network_connections:
       - name: ib0

--- a/examples/ipv6_disabled.yml
+++ b/examples/ipv6_disabled.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: all
+- name: Disable ipv6
+  hosts: all
   vars:
     network_connections:
       - name: eth0

--- a/examples/macvlan.yml
+++ b/examples/macvlan.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: network-test
+- name: Manage network MAC VLAN
+  hosts: network-test
   vars:
     network_connections:
       - name: eth0

--- a/examples/match_path_support.yml
+++ b/examples/match_path_support.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: all
+- name: Manage network using match path for interface
+  hosts: all
   vars:
     network_connections:
       - name: eth0

--- a/examples/network_state.yml
+++ b/examples/network_state.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: all
+- name: Manage network using network_state
+  hosts: all
   vars:
     network_state:
       interfaces:

--- a/examples/remove+down_profile.yml
+++ b/examples/remove+down_profile.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- name: Set {{ profile }} down
+- name: Set down profile {{ profile }}
   hosts: all
   vars:
     network_connections:

--- a/examples/route_table_support.yml
+++ b/examples/route_table_support.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: all
+- name: Manage routing tables
+  hosts: all
   tasks:
     - name: Add a new routing table
       lineinfile:

--- a/examples/team_simple.yml
+++ b/examples/team_simple.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: network-test
+- name: Manage teaming
+  hosts: network-test
   vars:
     network_connections:
       # Specify the team profile

--- a/examples/wireless_wpa3_owe.yml
+++ b/examples/wireless_wpa3_owe.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: all
+- name: Manage Wireless with OWE
+  hosts: all
   vars:
     network_connections:
       - name: wlan0

--- a/examples/wireless_wpa3_sae.yml
+++ b/examples/wireless_wpa3_sae.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: network-test
+- name: Manage WPA3 with SAE
+  hosts: network-test
   vars:
     network_connections:
       - name: wlan0

--- a/examples/wireless_wpa_psk.yml
+++ b/examples/wireless_wpa_psk.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- hosts: network-test
+- name: Manage WPA PSK
+  hosts: network-test
   vars:
     network_connections:
       - name: wlan0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -74,7 +74,7 @@
     # ansible-lint wants this to be a handler, but this is not appropriate as
     # NetworkManager must be restarted prior to the connections being created.
     # see (https://docs.ansible.com/ansible-lint/rules/default_rules.html)
-    - __network_package_install.changed  # noqa 503
+    - __network_package_install.changed  # noqa no-handler
 
 - name: Enable and start NetworkManager
   service:


### PR DESCRIPTION
The only thing we need to skip currently is using FQCN for ansible
builtin modules, plugins
Add `kinds` - otherwise, Ansible thinks anything not in a traditional
role path is a plain YAML file, and we don't get the additional
checking.
Ensure all plays are named.
Fix some other minor problems.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
