### PR TITLE
Add check for non-inclusive language; Clean up / Workaround non-inclusive words

### DIFF
--- a/.github/actions/custom-woke-action/LICENSE
+++ b/.github/actions/custom-woke-action/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright © 2020 Caitlin Elfring <celfring@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/.github/actions/custom-woke-action/README.md
+++ b/.github/actions/custom-woke-action/README.md
@@ -1,0 +1,78 @@
+# woke-action
+
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/get-woke/woke-action?logo=github&sort=semver)](https://github.com/get-woke/woke-action/releases)
+
+Woke GitHub Actions allow you to execute [`woke`](https://github.com/get-woke/woke) command within GitHub Actions.
+
+The output of the actions can be viewed from the Actions tab in the main repository view.
+
+## Usage
+
+The most common usage is to run `woke` on a file/directory. This workflow can be configured by adding the following content to the GitHub Actions workflow YAML file (ie in `.github/workflows/woke.yaml`).
+
+```yaml
+name: woke
+on:
+  - pull_request
+jobs:
+  woke:
+    name: woke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: woke
+        uses: get-woke/woke-action@v0
+        with:
+          # Cause the check to fail on any broke rules
+          fail-on-error: true
+```
+
+## Inputs
+
+Inputs to configure the `woke` GitHub Actions.
+
+| Input            | Default               | Description                                                                                       |
+|------------------|-----------------------|---------------------------------------------------------------------------------------------------|
+| `woke-args`      | `.`                   | (Optional) Additional flags to run woke with (see <https://github.com/get-woke/woke#usage>) |
+| `woke-version`   | latest                | (Optional) Release version of `woke` (defaults to latest version)                                 |
+| `fail-on-error`  | `false`               | (Optional) Fail the GitHub Actions check for any failures.                                        |
+| `workdir`        | `.`                   | (Optional) Run `woke` this working directory relative to the root directory.                      |
+| `github-token`   | `${{ github.token }}` | (Optional) Custom GitHub Access token (ie `${{ secrets.MY_CUSTOM_TOKEN }}`).                      |
+
+## License
+
+This application is licensed under the MIT License, you may obtain a copy of it
+[here](https://github.com/get-woke/woke-action/blob/main/LICENSE).
+
+## Only Changed Files
+
+If you're interested in only running `woke` against files that have changed in a PR,
+consider something like [Get All Changed Files Action](https://github.com/marketplace/actions/get-all-changed-files). With this, you can add a workflow that looks like:
+
+```yaml
+
+name: 'woke'
+on:
+  - pull_request
+jobs:
+  woke:
+    name: 'woke'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+
+      - uses: jitterbit/get-changed-files@v1
+        id: files
+
+      - name: 'woke'
+        uses: get-woke/woke-action@v0
+        with:
+          # Cause the check to fail on any broke rules
+          fail-on-error: true
+          # See https://github.com/marketplace/actions/get-all-changed-files
+          # for more options
+          woke-args: ${{ steps.files.outputs.added_modified }}
+```

--- a/.github/actions/custom-woke-action/action.yml
+++ b/.github/actions/custom-woke-action/action.yml
@@ -1,0 +1,46 @@
+name: 'Run woke'
+description: >-
+  Run woke on pull requests to detect non-inclusive language
+  in your source code.
+author: 'Caitlin Elfring (caitlinelfring)'
+inputs:
+  github-token:
+    description: 'GITHUB_TOKEN'
+    required: true
+    default: ${{ github.token }}
+  woke-args:
+    description: 'woke arguments'
+    default: '.'
+    required: false
+  fail-on-error:
+    description: |
+      Exit code when errors are found [true,false]
+      Default is `false`.
+    default: 'false'
+    required: false
+  workdir:
+    description: 'Working directory relative to the root directory.'
+    default: '.'
+    required: false
+  woke-version:
+    description: >-
+      woke version, defaults to the latest `v0` version.
+      Override to pin to a specific version
+    default: 'v0'
+    required: false
+runs:
+  using: 'composite'
+  steps:
+    - run: $GITHUB_ACTION_PATH/entrypoint.sh
+      shell: bash
+      env:
+        # INPUT_<VARIABLE_NAME> is not available in Composite run steps
+        # https://github.com/actions/runner/issues/665
+        INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
+        INPUT_WOKE_VERSION: ${{ inputs.woke-version }}
+        INPUT_WOKE_ARGS: ${{ inputs.woke-args }}
+        INPUT_FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
+        INPUT_WORKDIR: ${{ inputs.workdir }}
+branding:
+  icon: 'check-circle'
+  color: 'gray-dark'

--- a/.github/actions/custom-woke-action/entrypoint.sh
+++ b/.github/actions/custom-woke-action/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# shellcheck disable=SC2086
+
+set -e
+
+cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit 1
+
+TEMP_PATH="$(mktemp -d)"
+PATH="${TEMP_PATH}:$PATH"
+
+echo '::group:: Installing woke ... https://github.com/nhosoi/woke'
+curl https://raw.githubusercontent.com/nhosoi/woke/main/woke -o "${TEMP_PATH}/woke"
+chmod 0755 "${TEMP_PATH}/woke"
+echo '::endgroup::'
+
+echo '::group:: Running woke ...'
+woke \
+  --output github-actions \
+  --exit-1-on-failure="${INPUT_FAIL_ON_ERROR:-false}" \
+  ${INPUT_WOKE_ARGS}
+echo '::endgroup::'

--- a/.github/actions/custom-woke-action/testdata/bad.txt
+++ b/.github/actions/custom-woke-action/testdata/bad.txt
@@ -1,0 +1,1 @@
+I have a whitelist and a blacklist. What should I do about it?

--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -1,0 +1,19 @@
+# yamllint disable rule:line-length
+name: Check for non-inclusive language
+on:  # yamllint disable-line rule:truthy
+  - pull_request
+jobs:
+  woke:
+    name: woke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: custom woke
+        # Originally, uses: get-woke/woke-action@v0
+        uses: ./.github/actions/custom-woke-action
+        with:
+          woke-args: "-c https://raw.githubusercontent.com/linux-system-roles/tox-lsr/main/src/tox_lsr/config_files/woke.yml --count-only-error-for-failure"
+          # Cause the check to fail on any broke rules
+          fail-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,15 +170,15 @@ Changelog
 ### Changes
 
 - Use inclusive language
-- `slave` is deprecated in favor of `port`
-- `master` is deprecated in favor of `controller`
+- `slave` is deprecated in favor of `port` <!--- wokeignore:rule=slave -->
+- `master` is deprecated in favor of `controller` <!--- wokeignore:rule=master -->
 
 ### New features
 
 - Support disabling IPv6
 - Support `dns_options` when using one or more IPv4 nameservers
 - Support Ethtool coalesce settings
-- Support dummy interfaces
+- Support dummy interfaces <!--- wokeignore:rule=dummy -->
 
 ### Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -843,6 +843,7 @@ following options:
 
 - `all_ports_active`
 
+    <!--- wokeignore:rule=slave -->
     `all_slaves_active` in kernel and NetworkManager. The boolean value `false` drops
     the duplicate frames (received on inactive ports) and the boolean value `true`
     delivers the duplicate frames.

--- a/contributing.md
+++ b/contributing.md
@@ -399,7 +399,7 @@ comment. The available commands are:
 - [citest] - Trigger a re-test for all machines.
 - [citest bad] - Trigger a re-test for all machines with an error or failure status.
 - [citest pending] - Trigger a re-test for all machines with a pending status.
-- [citest commit:<sha1\>] - Whitelist a commit to be tested if the submitter is not
+- [citest commit:<sha1\>] - Specify a commit to be tested if the submitter is not
   trusted.
 
 How to reach us

--- a/module_utils/network_lsr/argument_validator.py
+++ b/module_utils/network_lsr/argument_validator.py
@@ -1794,6 +1794,7 @@ class ArgValidator_DictConnection(ArgValidatorDict):
         "vlan",
         "macvlan",
         "wireless",
+        # wokeignore:rule=dummy
         "dummy",
     ]
     VALID_PORT_TYPES = ["bridge", "bond", "team"]
@@ -1828,10 +1829,12 @@ class ArgValidator_DictConnection(ArgValidatorDict):
                     enum_values=ArgValidator_DictConnection.VALID_PORT_TYPES,
                 ),
                 ArgValidatorDeprecated(
+                    # wokeignore:rule=slave
                     "slave_type",
                     deprecated_by="port_type",
                 ),
                 ArgValidatorStr("controller"),
+                # wokeignore:rule=master
                 ArgValidatorDeprecated("master", deprecated_by="controller"),
                 ArgValidatorStr("interface_name", allow_empty=True),
                 ArgValidatorMac("mac"),

--- a/module_utils/network_lsr/ethtool.py
+++ b/module_utils/network_lsr/ethtool.py
@@ -23,7 +23,9 @@ def get_perm_addr(ifname):
     ETHTOOL_GPERMADDR ioctl command.
 
     Please for further documentation, see:
+    wokeignore:rule=master
     https://github.com/torvalds/linux/blob/master/include/uapi/linux/ethtool.h#L734
+    wokeignore:rule=master
     https://github.com/torvalds/linux/blob/master/include/uapi/linux/ethtool.h#L1388
     https://git.kernel.org/pub/scm/network/ethtool/ethtool.git/tree/ethtool.c#n4172
     """

--- a/tests/ensure_provider_tests.py
+++ b/tests/ensure_provider_tests.py
@@ -67,7 +67,7 @@ ibution_major_version | int < 9",
     },
     "playbooks/tests_bond_options.yml": {},
     "playbooks/tests_eth_dns_support.yml": {},
-    "playbooks/tests_dummy.yml": {},
+    "playbooks/tests_dummy.yml": {},  # wokeignore:rule=dummy
     "playbooks/tests_infiniband.yml": {},
     "playbooks/tests_ipv6_disabled.yml": {},
     "playbooks/tests_ipv6_dns_search.yml": {},

--- a/tests/playbooks/tests_bond_options.yml
+++ b/tests/playbooks/tests_bond_options.yml
@@ -88,6 +88,7 @@
             - { key: 'ad_actor_system', value: '00:00:5e:00:53:5d'}
             - { key: 'ad_select', value: 'stable'}
             - { key: 'ad_user_port_key', value: '1023'}
+            # wokeignore:rule=slave
             - { key: 'all_slaves_active', value: '1'}
             - { key: 'downdelay', value: '0'}
             - { key: 'lacp_rate', value: 'slow'}

--- a/tests/unit/test_network_connections.py
+++ b/tests/unit/test_network_connections.py
@@ -4226,8 +4226,10 @@ class TestValidator(Python26CompatTestCase):
             route_metric6_configured_ipv6_disabled,
         )
 
+    # wokeignore:rule=master
     def test_set_deprecated_master(self):
         """
+        wokeignore:rule=master
         When passing the deprecated "master" it is updated to "controller".
         """
         input_connections = [
@@ -4241,17 +4243,20 @@ class TestValidator(Python26CompatTestCase):
                 "state": "up",
                 "type": "ethernet",
                 "interface_name": "eth1",
-                "master": "prod2",
+                "master": "prod2",  # wokeignore:rule=master
             },
         ]
         connections = ARGS_CONNECTIONS.validate(input_connections)
         self.assertTrue(len(connections) == 2)
         for connection in connections:
             self.assertTrue("controller" in connection)
+            # wokeignore:rule=master
             self.assertTrue("master" not in connection)
 
+    # wokeignore:rule=slave
     def test_set_deprecated_slave_type(self):
         """
+        wokeignore:rule=slave
         When passing the deprecated "slave_type" it is updated to "port_type".
         """
         input_connections = [
@@ -4266,13 +4271,14 @@ class TestValidator(Python26CompatTestCase):
                 "type": "ethernet",
                 "interface_name": "eth1",
                 "controller": "prod2",
-                "slave_type": "bridge",
+                "slave_type": "bridge",  # wokeignore:rule=slave
             },
         ]
         connections = ARGS_CONNECTIONS.validate(input_connections)
         self.assertTrue(len(connections) == 2)
         for connection in connections:
             self.assertTrue("port_type" in connection)
+            # wokeignore:rule=slave
             self.assertTrue("slave_type" not in connection)
 
 
@@ -4376,7 +4382,7 @@ class TestValidatorMatch(Python26CompatTestCase):
         result = self.validator.validate(self.test_profile)
         self.assertEqual(result["match"], {"path": ["pci-0000:00:03.0"]})
 
-        self.test_profile["type"] = "dummy"
+        self.test_profile["type"] = "dummy"  # wokeignore:rule=dummy
         self.assertRaisesRegex(
             ValidationError,
             "'match.path' settings are only supported for type 'ethernet' or 'infiniband'",


### PR DESCRIPTION
Add check for non-inclusive language
    
Add a check for usage of terms and language that is considered non-inclusive. We are using the woke tool for this with a wordlist that can be found at
https://github.com/linux-system-roles/tox-lsr/blob/main/src/tox_lsr/config_files/woke.yml
    
Note: this commit uses the customized woke placed locally in .github/actions/custom-woke-action to support a new option `--count-only-error-for-failure` option. The local action custom-woke-action will be replaced with the official woke once https://github.com/get-woke/woke/pull/252 (Add an option "--count-only-error-for-failure") is processed.

Clean up / Workaround non-inclusive words.
- CHANGELOG.md
- README.md
- contributing.md
- library/network_connections.py
- module_utils/network_lsr/argument_validator.py
- module_utils/network_lsr/ethtool.py
- tests/ensure_provider_tests.py
- tests/playbooks/tests_bond_options.yml
- tests/unit/test_network_connections.py

Additional note: There are too many warning level words `master` and `dump` to skip with `# wokeignore:rule=word`. So, I use the customized woke to skip the warning words in this PR.  The ` # wokeignore:rule=word` is mainly applied to the error level word `slave` (and warning level words in the python codes).