### PR TITLE
Version 1.11.1 - CHANGELOG.md [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+[1.11.1] - 2023-01-20
+--------------------
+
+### New Features
+
+- none
+
+### Bug Fixes
+
+- ansible-lint 6.x updates
+
+### Other Changes
+
+- Support running the tests with ANSIBLE_GATHERING=explicit
+- Clean up / Workaround non-inclusive words
+- Add check for non-inclusive language
+- fix the ansible-pull link, the old do not work
+
 [1.11.0] - 2022-12-12
 --------------------
 


### PR DESCRIPTION
[1.11.1] - 2023-01-20
--------------------

### New Features

- none

### Bug Fixes

- ansible-lint 6.x updates

### Other Changes

- Support running the tests with ANSIBLE_GATHERING=explicit
- Clean up / Workaround non-inclusive words
- Add check for non-inclusive language
- fix the ansible-pull link, the old do not work

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
