### PR TITLE
tag all bond tests with expfail

### DIFF
--- a/tests/playbooks/tests_bond.yml
+++ b/tests/playbooks/tests_bond.yml
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
 - hosts: all
+  tags:
+    - tests::expfail
   vars:
     controller_profile: bond0
     controller_device: nm-bond

--- a/tests/playbooks/tests_bond_cloned_mac.yml
+++ b/tests/playbooks/tests_bond_cloned_mac.yml
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
 - hosts: all
+  tags:
+    - tests::expfail
   vars:
     controller_profile: bond0
     controller_device: nm-bond

--- a/tests/playbooks/tests_bond_deprecated.yml
+++ b/tests/playbooks/tests_bond_deprecated.yml
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
 - hosts: all
+  tags:
+    - tests::expfail
   vars:
     controller_profile: bond0
     controller_device: deprecated-bond

--- a/tests/playbooks/tests_bond_options.yml
+++ b/tests/playbooks/tests_bond_options.yml
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
 - hosts: all
+  tags:
+    - tests::expfail
   vars:
     controller_profile: bond0
     controller_device: nm-bond

--- a/tests/playbooks/tests_bond_removal.yml
+++ b/tests/playbooks/tests_bond_removal.yml
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
 - hosts: all
+  tags:
+    - tests::expfail
   vars:
     controller_profile: bond0
     controller_device: nm-bond


### PR DESCRIPTION
The bond tests fail regularly in our single host downstream testing,
so mark them as `expfail` (expect to fail) so that these failures
do not clutter up our test results.

We have tried to fix this in the past - several times over the past
three years, at a cost of many man weeks of effort  - and the fixes just
don't seem to "take".  We have reached the point where we need to cut
our losses and just skip these tests.  Perhaps at some point in the
future we can revisit this issue.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
