### PR TITLE
Address CodeQL warnings

### DIFF
--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -818,12 +818,14 @@ class NMUtil:
             try:
                 con_a.normalize()
             except Exception:
+                # We ignore any errors that might happen
                 pass
         if normalize_b:
             con_b = NM.SimpleConnection.new_clone(con_b)
             try:
                 con_b.normalize()
             except Exception:
+                # We ignore any errors that might happen
                 pass
         if compare_flags is None:
             compare_flags = NM.SettingCompareFlags.IGNORE_TIMESTAMP

--- a/module_utils/network_lsr/argument_validator.py
+++ b/module_utils/network_lsr/argument_validator.py
@@ -258,20 +258,17 @@ class ArgValidatorRouteTable(ArgValidator):
 
     def _validate_impl(self, value, name):
         table = None
-        try:
-            if isinstance(value, bool):
-                # bool can (probably) be converted to integer type,
-                # but here we don't want to accept a boolean value.
-                pass
-            elif isinstance(value, int):
-                table = int(value)
-            elif isinstance(value, Util.STRING_TYPE):
-                try:
-                    table = int(value)
-                except Exception:
-                    table = value
-        except Exception:
+        if isinstance(value, bool):
+            # bool can (probably) be converted to integer type,
+            # but here we don't want to accept a boolean value.
             pass
+        elif isinstance(value, int):
+            table = value
+        elif isinstance(value, Util.STRING_TYPE):
+            try:
+                table = int(value)
+            except Exception:
+                table = value
         if table is None:
             raise ValidationError(
                 name,
@@ -336,6 +333,7 @@ class ArgValidatorNum(ArgValidator):
                 if isinstance(value, Util.STRING_TYPE) or v2 == value:
                     v = v2
         except Exception:
+            # Exception handling is done next.
             pass
         if v is None:
             raise ValidationError(
@@ -374,11 +372,13 @@ class ArgValidatorRange(ArgValidator):
                 try:
                     range = (int(match_group.group(1)), int(match_group.group(2)))
                 except Exception:
+                    # Exception handling is done below.
                     pass
             else:
                 try:
                     range = (int(value), int(value))
                 except Exception:
+                    # Exception handling is done below.
                     pass
         elif isinstance(value, bool):
             # bool can (probably) be converted to integer type,
@@ -425,6 +425,7 @@ class ArgValidatorBool(ArgValidator):
             if isinstance(value, Util.STRING_TYPE) or isinstance(value, int):
                 return Util.boolean(value)
         except Exception:
+            # Exception handling is done next.
             pass
         raise ValidationError(name, "must be an boolean but is '%s'" % (value))
 
@@ -2665,6 +2666,7 @@ class IPRouteUtils(object):
                     try:
                         tableid = int(table[2:], 16)
                     except Exception:
+                        # Exception handling is done next.
                         pass
             if tableid is None or tableid < 0 or tableid > 0xFFFFFFFF:
                 continue

--- a/module_utils/network_lsr/utils.py
+++ b/module_utils/network_lsr/utils.py
@@ -339,6 +339,7 @@ class Util:
         if addr_family in ["6", "inet6", "ip6", "ipv6", "IPv6"]:
             return socket.AF_INET6
         Util.addr_family_check(addr_family)
+        return None
 
     @staticmethod
     def addr_family_prefix_length(family):
@@ -348,6 +349,7 @@ class Util:
         if addr_family == socket.AF_INET6:
             return 128
         Util.addr_family_check(addr_family)
+        return None
 
     @staticmethod
     def addr_family_valid_prefix(family, prefix):


### PR DESCRIPTION
library/network_connections.py
- 'except' clause does nothing but pass and there is no explanatory comment.
    
module_utils/network_lsr/argument_validator.py
- 'except' clause does nothing but pass and there is no explanatory comment.
    
module_utils/network_lsr/utils.py
- Mixing implicit and explicit returns may indicate an error as implicit returns always return None.
    
tests/unit/test_network_connections.py
- Module 'network_lsr.argument_validator' is imported with both 'import' and 'import from'.
- assertTrue(a == b) cannot provide an informative message. Using assertEqual(a, b) instead will give more informative messages.