### PR TITLE
Non-inclusive words - Fix wokeignore comment in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,10 +843,9 @@ following options:
 
 - `all_ports_active`
 
-    <!--- wokeignore:rule=slave -->
-    `all_slaves_active` in kernel and NetworkManager. The boolean value `false` drops
-    the duplicate frames (received on inactive ports) and the boolean value `true`
-    delivers the duplicate frames.
+    `all_slaves_active` <!--- wokeignore:rule=slave ---> in kernel and NetworkManager.
+    The boolean value `false` drops the duplicate frames (received on inactive ports)
+    and the boolean value `true` delivers the duplicate frames.
 
 - `arp_all_targets`
 


### PR DESCRIPTION
To allow a "non-inclusive word" in README.md, a wokeignore rule was added as follows.
```
   <!--- wokeignore:rule=word -->
   "non-inclusive word" in kernel and NetworkManager.
```
When the markdown format is converged to the html format, the comment line is treated as a blank line proceeded by `<p>`.
```
   <p><!--- wokeignore:rule=word --><br />
   "non-inclusive word" in kernel and NetworkManager.
```
Starting with `<p>` and being followed by`<br />`, the wokeignore rule loses the ability to make the inclusive language utility `woke` skip checking the non-inclusive word in the next line.

Instead of putting the wokeignore rule comment above the non- inclusive word, it's placed in the same line.

Signed-off-by: Noriko Hosoi <nhosoi@redhat.com>