### PR TITLE
add back python-26 unit test

### DIFF
--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -69,3 +69,13 @@ jobs:
           *) toxenvs="${toxenvs},coveralls" ;;
           esac
           TOXENV="$toxenvs" lsr_ci_runtox
+  python-26:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout PR
+        uses: actions/checkout@v3
+
+      - name: Run py26 tests
+        uses: linux-system-roles/lsr-gh-action-py26@1.0.2
+        env:
+          TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"


### PR DESCRIPTION
The PR https://github.com/linux-system-roles/network/pull/556
erroneously removed the python-26 job for unit testing.  This
PR adds it back.

See also https://github.com/linux-system-roles/.github/pull/10

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
