### PR TITLE
Upload coverage files to codecov

### DIFF
--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -69,6 +69,10 @@ jobs:
           *) toxenvs="${toxenvs},coveralls" ;;
           esac
           TOXENV="$toxenvs" lsr_ci_runtox
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+
   python-26:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add a github action task to upload the coverage files
to codecov after the unit tests are complete.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
