### PR TITLE
use tox-lsr version 2.13.2

### DIFF
--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip
-          pip install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
+          pip install "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"
           # If you have additional OS dependency packages e.g. libcairo2-dev
           # then put them in .github/config/ubuntu-requirements.txt, one
           # package per line.
@@ -78,4 +78,4 @@ jobs:
       - name: Run py26 tests
         uses: linux-system-roles/lsr-gh-action-py26@1.0.2
         env:
-          TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
+          TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"


### PR DESCRIPTION
Use tox-lsr version 2.13.2 in order to pick up the codecov
fix.
https://github.com/linux-system-roles/tox-lsr/pull/109

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
