### PR TITLE
ansible-lint: Fix name[casing] and jinja[spacing] warnings [citest skip]

### DIFF
--- a/tests/playbooks/integration_pytest_python3.yml
+++ b/tests/playbooks/integration_pytest_python3.yml
@@ -32,13 +32,13 @@
   hosts: all
   tasks:
     - block:
-        - name: create tempdir for code to test
+        - name: Create tempdir for code to test
           tempfile:
             state: directory
             prefix: lsrtest_
           register: _rundir
 
-        - name: get tempfile for tar
+        - name: Get tempfile for tar
           tempfile:
             prefix: lsrtest_
             suffix: ".tar"
@@ -47,7 +47,7 @@
 
         - include_tasks: ../tasks/get_modules_and_utils_paths.yml
 
-        - name: get tests directory
+        - name: Get tests directory
           set_fact:
             tests_directory: "{{ lookup('first_found', params) }}"
           vars:
@@ -116,7 +116,7 @@
           debug:
             msg: path {{ _lsr_python_path }}
 
-        - name: "ls -alrtFR {{ _rundir.path }}"
+        - name: "List the files in {{ _rundir.path }}"
           command: ls -alrtFR {{ _rundir.path }}
 
         - block:
@@ -133,7 +133,7 @@
                 var: playbook_run.stdout_lines
 
         - block:
-            - name: install network-scripts when running pytest with initscripts
+            - name: Install network-scripts when running pytest with initscripts
               package:
                 name: network-scripts
                 state: present
@@ -149,13 +149,13 @@
             - debug:
                 var: playbook_run.stdout_lines
       always:
-        - name: remove local tar file
+        - name: Remove local tar file
           file:
             state: absent
             path: "{{ temptar.path }}"
           delegate_to: localhost
 
-        - name: remove tempdir
+        - name: Remove tempdir
           file:
             state: absent
             path: "{{ _rundir.path }}"

--- a/tests/playbooks/tests_bridge.yml
+++ b/tests/playbooks/tests_bridge.yml
@@ -6,7 +6,7 @@
     interface: LSR-TST-br31
 
   tasks:
-    - name: "set interface={{ interface }}"
+    - name: "Set interface={{ interface }}"
       set_fact:
         interface: "{{ interface }}"
     - include_tasks: tasks/show_interfaces.yml

--- a/tests/playbooks/tests_bridge_cloned_mac.yml
+++ b/tests/playbooks/tests_bridge_cloned_mac.yml
@@ -3,7 +3,7 @@
 - name: Test configuring bridges
   hosts: all
   tasks:
-    - name: define vars
+    - name: Define vars
       set_fact:
         interface: "LSR-TST-br31"
         cloned_mac: "12:23:34:45:56:70"

--- a/tests/playbooks/tests_checkpoint_cleanup.yml
+++ b/tests/playbooks/tests_checkpoint_cleanup.yml
@@ -20,7 +20,7 @@
   tasks:
     - block:
         # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1832897
-        - name: install dbus-tools
+        - name: Install dbus-tools
           package:
             name: dbus-tools
             state: present
@@ -40,7 +40,7 @@
         - include_tasks: tasks/assert_device_present.yml
         - include_tasks: tasks/assert_profile_present.yml
         # Use internal module directly for speedup
-        - name: use network_connections
+        - name: Use network_connections
           network_connections:
             provider: nm
             connections:
@@ -52,14 +52,14 @@
                   auto6: false
           ignore_errors: true
           register: error_trigger
-        - name: assert that the module call did not fail
+        - name: Assert that the module call did not fail
           assert:
             fail_msg: The module call did not fail. Therefore the test
               condition was not triggered. This test needs to be adjusted or
               dropped.
             that: error_trigger.failed
         # yamllint disable-line rule:line-length
-        - name: get NM dbus objects
+        - name: Get NM dbus objects
           command: busctl --system tree --list org.freedesktop.NetworkManager
           register: nm_dbus_objects
         - name: Show nm_dbus_objects

--- a/tests/playbooks/tests_eth_dns_support.yml
+++ b/tests/playbooks/tests_eth_dns_support.yml
@@ -10,7 +10,7 @@
 
 
   tasks:
-    - name: "set type={{ type }} and interface={{ interface }}"  # noqa name
+    - name: "Set type={{ type }} and interface={{ interface }}"  # noqa name
       set_fact:
         type: "{{ type }}"
         interface: "{{ interface }}"

--- a/tests/playbooks/tests_ethernet.yml
+++ b/tests/playbooks/tests_ethernet.yml
@@ -16,7 +16,7 @@
     interface: lsr27
 
   tasks:
-    - name: "set type={{ type }} and interface={{ interface }}"  # noqa name
+    - name: "Set type={{ type }} and interface={{ interface }}"  # noqa name
       set_fact:
         type: "{{ type }}"
         interface: "{{ interface }}"

--- a/tests/playbooks/tests_ipv6_disabled.yml
+++ b/tests/playbooks/tests_ipv6_disabled.yml
@@ -9,7 +9,7 @@
     interface: ethtest0
 
   tasks:
-    - name: "set type={{ type }} and interface={{ interface }}"  # noqa name
+    - name: "Set type={{ type }} and interface={{ interface }}"  # noqa name
       set_fact:
         type: "{{ type }}"
         interface: "{{ interface }}"
@@ -65,7 +65,7 @@
         msg: "ipv6.method disabled is configured incorrectly"
       when: not __network_connections_result.failed
 
-    - name: set the connection_failed flag
+    - name: Set the connection_failed flag
       set_fact:
         connection_failed: true
       when: __network_connections_result.failed

--- a/tests/playbooks/tests_network_state.yml
+++ b/tests/playbooks/tests_network_state.yml
@@ -11,7 +11,7 @@
 
 
   tasks:
-    - name: "set type={{ type }} and interface={{ interface0 }}"  # noqa name
+    - name: "Set type={{ type }} and interface={{ interface0 }}"  # noqa name
       set_fact:
         type: "{{ type }}"
         interface: "{{ interface0 }}"
@@ -20,7 +20,7 @@
       vars:
         state: present
     - include_tasks: tasks/assert_device_present.yml
-    - name: "set type={{ type }} and interface={{ interface1 }}"  # noqa name
+    - name: "Set type={{ type }} and interface={{ interface1 }}"  # noqa name
       set_fact:
         type: "{{ type }}"
         interface: "{{ interface1 }}"
@@ -209,7 +209,7 @@
 
     - include_tasks: tasks/delete_interface.yml
     - include_tasks: tasks/assert_device_absent.yml
-    - name: "set interface={{ interface0 }}"
+    - name: "Set interface={{ interface0 }}"
       set_fact:
         type: "{{ type }}"
         interface: "{{ interface0 }}"

--- a/tests/playbooks/tests_route_table.yml
+++ b/tests/playbooks/tests_route_table.yml
@@ -10,7 +10,7 @@
 
 
   tasks:
-    - name: "set type={{ type }} and interface={{ interface }}"  # noqa name
+    - name: "Set type={{ type }} and interface={{ interface }}"  # noqa name
       set_fact:
         type: "{{ type }}"
         interface: "{{ interface }}"

--- a/tests/playbooks/tests_routing_rules.yml
+++ b/tests/playbooks/tests_routing_rules.yml
@@ -9,7 +9,7 @@
     interface: ethtest0
 
   tasks:
-    - name: "set type={{ type }} and interface={{ interface }}"  # noqa name
+    - name: "Set type={{ type }} and interface={{ interface }}"  # noqa name
       set_fact:
         type: "{{ type }}"
         interface: "{{ interface }}"

--- a/tests/playbooks/tests_states.yml
+++ b/tests/playbooks/tests_states.yml
@@ -31,7 +31,7 @@
               # Device should be present because of autoconnect: true by
               # default for NM (this might be considered a bug)
               - what: tasks/assert_device_present.yml
-                when: "{{ network_provider == 'nm' }}"
+                when: network_provider == 'nm'
             lsr_cleanup:
               - tasks/cleanup_profile+device.yml
 
@@ -103,7 +103,7 @@
               - tasks/assert_profile_absent.yml
             lsr_assert_when:
               - what: tasks/assert_device_absent.yml
-                when: "{{ network_provider == 'nm' }}"
+                when: network_provider == 'nm'
             lsr_cleanup:
               - tasks/cleanup_profile+device.yml
 
@@ -128,6 +128,6 @@
               - tasks/get_NetworkManager_NVR.yml
             lsr_assert_when:
               - what: tasks/assert_device_absent.yml
-                when: "{{ network_provider == 'nm' }}"
+                when: network_provider == 'nm'
             lsr_cleanup:
               - tasks/cleanup_profile+device.yml

--- a/tests/playbooks/tests_switch_provider.yml
+++ b/tests/playbooks/tests_switch_provider.yml
@@ -5,7 +5,7 @@
 - hosts: all
   name: Switch initscripts provider to nm
   tasks:
-    - name: set fact to use initscripts network_provider
+    - name: Set fact to use initscripts network_provider
       set_fact:
         network_provider: initscripts
         interface: LST-TST-br34
@@ -29,7 +29,7 @@
         profile: "{{ interface }}"
     # The initscripts should not remove the interface for down/absent
     - include_tasks: tasks/assert_device_present.yml
-    - name: set fact to use nm network_provider
+    - name: Set fact to use nm network_provider
       set_fact:
         network_provider: nm
       tags:

--- a/tests/playbooks/tests_team_plugin_installation.yml
+++ b/tests/playbooks/tests_team_plugin_installation.yml
@@ -2,12 +2,12 @@
 ---
 - hosts: all
   tasks:
-    - name: remove the NetworkManager-team package
+    - name: Remove the NetworkManager-team package
       package:
         name: "NetworkManager-team"
         state: absent
 
-    - name: "get the rpm package facts"
+    - name: "Get the rpm package facts"
       package_facts:
         manager: "auto"
 
@@ -28,7 +28,7 @@
             type: team
             interface_name: team0
 
-    - name: "get the rpm package facts"
+    - name: "Get the rpm package facts"
       package_facts:
         manager: "auto"
 

--- a/tests/playbooks/tests_wireless_plugin_installation.yml
+++ b/tests/playbooks/tests_wireless_plugin_installation.yml
@@ -2,12 +2,12 @@
 ---
 - hosts: all
   tasks:
-    - name: remove the NetworkManager-wifi package
+    - name: Remove the NetworkManager-wifi package
       package:
         name: "NetworkManager-wifi"
         state: absent
 
-    - name: "get the rpm package facts"
+    - name: "Get the rpm package facts"
       package_facts:
         manager: "auto"
 
@@ -17,7 +17,7 @@
           - "'NetworkManager-wifi' not in ansible_facts.packages"
         msg: "NetworkManager-wifi is not removed before wirelss configuration"
 
-    - name: "wireless configuration"
+    - name: "Wireless configuration"
       include_role:
         name: linux-system-roles.network
       vars:
@@ -29,7 +29,7 @@
               key_mgmt: "wpa-psk"
               password: "p@55w0rD"
 
-    - name: "get the rpm package facts"
+    - name: "Get the rpm package facts"
       package_facts:
         manager: "auto"
 

--- a/tests/tasks/assert_device_absent.yml
+++ b/tests/tasks/assert_device_absent.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
 - include_tasks: get_interface_stat.yml
-- name: "assert that the interface is absent - '{{ interface }}'"
+- name: "Assert that the interface is absent - '{{ interface }}'"
   assert:
     that: not interface_stat.stat.exists
     msg: "{{ interface }} exists"

--- a/tests/tasks/assert_device_present.yml
+++ b/tests/tasks/assert_device_present.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
 - include_tasks: get_interface_stat.yml
-- name: "assert that the interface is present - '{{ interface }}'"
+- name: "Assert that the interface is present - '{{ interface }}'"
   assert:
     that: interface_stat.stat.exists
     msg: "{{ interface }} does not exist"

--- a/tests/tasks/assert_profile_absent.yml
+++ b/tests/tasks/assert_profile_absent.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
 - include_tasks: get_profile_stat.yml
-- name: "assert that the profile is absent - '{{ profile }}'"
+- name: "Assert that the profile is absent - '{{ profile }}'"
   assert:
     that: not lsr_net_profile_exists
     msg: "profile {{ profile }} does exist"

--- a/tests/tasks/assert_profile_present.yml
+++ b/tests/tasks/assert_profile_present.yml
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
 - include_tasks: get_profile_stat.yml
-- name: "assert that the profile is present - '{{ profile }}'"
+- name: "Assert that the profile is present - '{{ profile }}'"
   assert:
     that: lsr_net_profile_exists
     msg: "profile {{ profile }} does not exist"
 
-- name: "assert that the ansible managed comment is present in '{{ profile }}'"
+- name: "Assert that the ansible managed comment is present in '{{ profile }}'"
   assert:
     that: lsr_net_profile_ansible_managed
     msg: "profile {{ profile }} does not have the ansible managed comment"

--- a/tests/tasks/delete_interface.yml
+++ b/tests/tasks/delete_interface.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- name: remove test interface if necessary
+- name: Remove test interface if necessary
   command: "ip link del {{ interface }}"
   ignore_errors: true  # noqa ignore-errors
   changed_when: false

--- a/tests/tasks/get_modules_and_utils_paths.yml
+++ b/tests/tasks/get_modules_and_utils_paths.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- name: set collection paths
+- name: Set collection paths
   set_fact:
     collection_paths: |
       {{
@@ -10,7 +10,7 @@
         select | list
       }}
 
-- name: set search paths
+- name: Set search paths
   set_fact:
     modules_search_path: |
         {{
@@ -39,7 +39,7 @@
 # - ansible_collections/fedora/linux_system_roles/plugins/modules
 # would translate to tar -C /home/user/.ansible/collections \
 # ansible_collections/fedora/linux_system_roles/plugins/modules
-- name: find parent directory and path of modules
+- name: Find parent directory and path of modules
   shell: |
     set -euxo pipefail
     for dir in {{ modules_search_path | join(" ") }}; do
@@ -66,7 +66,7 @@
   register: modules_parent_and_dir
   changed_when: false
 
-- name: find parent directory and path of module_utils
+- name: Find parent directory and path of module_utils
   shell: |
     set -euxo pipefail
     for dir in {{ module_utils_search_path | join(" ") }}; do

--- a/tests/tasks/get_profile_stat.yml
+++ b/tests/tasks/get_profile_stat.yml
@@ -5,7 +5,7 @@
     lsr_net_profile_exists: false
     lsr_net_profile_ansible_managed: false
 
-- name: stat profile file
+- name: Stat profile file
   stat:
     get_attributes: false
     get_checksum: false

--- a/tests/tasks/run_test.yml
+++ b/tests/tasks/run_test.yml
@@ -41,7 +41,7 @@
     - name: Conditional asserts
       include_tasks: "{{ item['what'] }}"
       when: item['when']
-      loop: "{{ lsr_assert_when|default([]) }}"
+      loop: "{{ lsr_assert_when | default([]) }}"
 
     - name: "Success in test '{{ lsr_description }}'"
       debug:

--- a/tests/tasks/run_test.yml
+++ b/tests/tasks/run_test.yml
@@ -20,25 +20,25 @@
 
     - include_tasks: tasks/show_interfaces.yml
 
-    - name: setup
+    - name: Setup
       include_tasks: "{{ item }}"
       loop: "{{ lsr_setup }}"
       tags:
         - "tests::setup"
 
-    - name: test
+    - name: Test
       include_tasks: "{{ item }}"
       loop: "{{ lsr_test }}"
       tags:
         - "tests::test"
 
-    - name: asserts
+    - name: Asserts
       include_tasks: "{{ item }}"
       loop: "{{ lsr_assert }}"
       tags:
         - "tests::assert"
 
-    - name: conditional asserts
+    - name: Conditional asserts
       include_tasks: "{{ item['what'] }}"
       when: item['when']
       loop: "{{ lsr_assert_when|default([]) }}"
@@ -62,7 +62,7 @@
         msg: "!!!!! Failure in test '{{ lsr_description }}' !!!!!"
 
   always:
-    - name: cleanup
+    - name: Cleanup
       include_tasks: "{{ item }}"
       loop: "{{ lsr_cleanup }}"
       tags:

--- a/tests/tasks/setup_mock_wifi_wpa3_owe.yml
+++ b/tests/tasks/setup_mock_wifi_wpa3_owe.yml
@@ -10,7 +10,7 @@
 # Even though hostapd can be installed via EPEL 8, Opportunistic Wireless Encryption
 # (OWE) has not been enabled by default. To warrant the test support on RHEL(dist-tag),
 # we setup hostapd copr repo to enable OWE option.
-- name: install hostapd and mac80211_hwsim kernel module in CentOS 8
+- name: Install hostapd and mac80211_hwsim kernel module in CentOS 8
   shell: |
     dnf -y copr enable liangwen12year/hostapd-owe
     dnf -y install hostapd
@@ -24,14 +24,14 @@
     - ansible_distribution_major_version == '8'
     - ansible_distribution == 'CentOS'
 
-- name: install hostapd in Fedora
+- name: Install hostapd in Fedora
   shell: |
     dnf -y copr enable liangwen12year/hostapd-owe
     dnf -y install hostapd
   when:
     - ansible_distribution == 'Fedora'
 
-- name: install mac80211_hwsim kernel modules in Fedora
+- name: Install mac80211_hwsim kernel modules in Fedora
   shell: |
     dnf -y install koji
     koji download-build --arch=$(uname -p) kernel-modules-internal-$(uname -r)

--- a/tests/tasks/setup_mock_wifi_wpa3_sae.yml
+++ b/tests/tasks/setup_mock_wifi_wpa3_sae.yml
@@ -10,7 +10,7 @@
 # Even though hostapd can be installed via EPEL 8, Simultaneous Authentication
 # of Equals (SAE) has not been enabled by default. To warrant the test support
 # on CentOS 8, we setup hostapd copr repo to enable SAE option.
-- name: install hostapd and mac80211_hwsim kernel module in CentOS 8
+- name: Install hostapd and mac80211_hwsim kernel module in CentOS 8
   shell: |
     dnf -y copr enable liangwen12year/hostapd-owe
     dnf -y install hostapd
@@ -24,7 +24,7 @@
     - ansible_distribution_major_version == '8'
     - ansible_distribution == 'CentOS'
 
-- name: install hostapd in Fedora
+- name: Install hostapd in Fedora
   package:
     name:
       - hostapd
@@ -34,7 +34,7 @@
 
 # Since DNF package manager can not warrant installing the kernel module with the same
 # version as the kernel in target machine, install the kernel module from koji instead
-- name: install mac80211_hwsim kernel module in Fedora
+- name: Install mac80211_hwsim kernel module in Fedora
   shell: |
     dnf -y install koji
     koji download-build --arch=$(uname -p) kernel-modules-internal-$(uname -r)

--- a/tests/tasks/test_802.1x_capath.yml
+++ b/tests/tasks/test_802.1x_capath.yml
@@ -73,7 +73,7 @@
               ca_path: /etc/pki/tls/my_ca_certs
     - name: "TEST: I can ping the EAP server"
       command: ping -c1 203.0.113.1
-    - name: trigger failure in case the role did not fail
+    - name: Trigger failure in case the role did not fail
       fail:
         msg: after test
   rescue:

--- a/tests/tests_helpers_and_asserts.yml
+++ b/tests/tests_helpers_and_asserts.yml
@@ -5,13 +5,13 @@
   tasks:
     - include_tasks: tasks/el_repo_setup.yml
 
-    - name: test veth interface management
+    - name: Test veth interface management
       include_tasks: tasks/create_and_remove_interface.yml
       vars:
         type: veth
         interface: veth1298
 
-    - name: test veth interface management
+    - name: Test veth interface management
       include_tasks: tasks/create_and_remove_interface.yml
       vars:
         type: dummy

--- a/tests/tests_unit.yml
+++ b/tests/tests_unit.yml
@@ -19,16 +19,16 @@
         - python2-mock
 
 - hosts: all
-  name: execute python unit tests
+  name: Execute python unit tests
   tasks:
     - block:
-        - name: create tempdir for code to test
+        - name: Create tempdir for code to test
           tempfile:
             state: directory
             prefix: lsrtest_
           register: _rundir
 
-        - name: get tempfile for tar
+        - name: Get tempfile for tar
           tempfile:
             prefix: lsrtest_
             suffix: ".tar"
@@ -104,7 +104,7 @@
               _rundir.path
             }}"
 
-        - name: "ls -alrtFR {{ _rundir.path }}"
+        - name: "List the files in {{ _rundir.path }}"
           command: ls -alrtFR {{ _rundir.path }}
         - debug:
             msg: path {{ _lsr_python_path }}
@@ -149,13 +149,13 @@
           when: python3_result is succeeded
 
       always:
-        - name: remove local tar file
+        - name: Remove local tar file
           file:
             state: absent
             path: "{{ temptar.path }}"
           delegate_to: localhost
 
-        - name: remove tempdir
+        - name: Remove tempdir
           file:
             state: absent
             path: "{{ _rundir.path }}"


### PR DESCRIPTION
All names of the tasks should start with an uppercase letter.