### PR TITLE
update tox-lsr to 2.13.2; update ansible-lint configuration; start of support for merge queues

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,11 +1,6 @@
 ---
 profile: production
 extra_vars:
-  # In order to fix the ansible-lint 6.x parser-error, the file
-  # `tests/get_coverage.yml` has to be declared as the playbook and an extra
-  # variable `test_playbook` has to be defined. The value of the variable
-  # `test_playbook`is less important which only meets the purpose of passing
-  # the ansible-lint 6.x check
   test_playbook: tests_default.yml
 kinds:
   - yaml: "**/meta/collection-requirements.yml"

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"
 
       - name: Convert role to collection format
         run: |


### PR DESCRIPTION
Update tox-lsr to 2.13.2

Update ansible-lint configuration

Add support for merge queues to github actions
This doesn't mean all system roles support merge queues,
this is just a preliminary step

See https://github.com/linux-system-roles/.github/pull/21

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
