### PR TITLE
ansible-lint: Fix ignore-errors failures

### DIFF
--- a/tests/get_coverage.yml
+++ b/tests/get_coverage.yml
@@ -30,7 +30,7 @@
       command: "{{ coverage }} combine"
       environment:
         COVERAGE_FILE: "{{ coverage_file }}"
-      ignore_errors: true
+      failed_when: false
       changed_when: false
 
     - name: remove old data

--- a/tests/playbooks/manual_test_ethtool_coalesce.yml
+++ b/tests/playbooks/manual_test_ethtool_coalesce.yml
@@ -112,7 +112,7 @@
                   - name: "{{ interface }}"
                     persistent_state: absent
                     state: down
-              ignore_errors: true
+              failed_when: false
             - include_tasks: tasks/manage_test_interface.yml
               vars:
                 state: absent

--- a/tests/playbooks/tests_802_1x.yml
+++ b/tests/playbooks/tests_802_1x.yml
@@ -106,7 +106,7 @@
                   - name: br1
                     persistent_state: absent
                     state: down
-              ignore_errors: true
+              failed_when: false
             - include_tasks: tasks/cleanup_802_1x_server.yml
             - name: Remove test certificates
               file:

--- a/tests/playbooks/tests_bond.yml
+++ b/tests/playbooks/tests_bond.yml
@@ -101,9 +101,9 @@
                   - name: "{{ controller_profile }}"
                     persistent_state: absent
                     state: down
-              ignore_errors: true
+              failed_when: false
             - command: ip link del {{ controller_device }}
-              ignore_errors: true
+              failed_when: false
             - import_tasks: tasks/remove_test_interfaces_with_dhcp.yml
             - name: "Restore the /etc/resolv.conf for initscript"
               command: mv -vf /etc/resolv.conf.bak /etc/resolv.conf

--- a/tests/playbooks/tests_bond_cloned_mac.yml
+++ b/tests/playbooks/tests_bond_cloned_mac.yml
@@ -120,9 +120,9 @@
                   - name: "{{ controller_profile }}"
                     persistent_state: absent
                     state: down
-              ignore_errors: true
+              failed_when: false
             - command: ip link del {{ controller_device }}
-              ignore_errors: true
+              failed_when: false
             - import_tasks: tasks/remove_test_interfaces_with_dhcp.yml
             - name: Restore the /etc/resolv.conf for initscript
               command: mv -vf /etc/resolv.conf.bak /etc/resolv.conf

--- a/tests/playbooks/tests_bond_deprecated.yml
+++ b/tests/playbooks/tests_bond_deprecated.yml
@@ -97,7 +97,7 @@
                   - name: "{{ controller_profile }}"
                     persistent_state: absent
                     state: down
-              ignore_errors: true
+              failed_when: false
             - command: ip link del {{ controller_device }}
-              ignore_errors: true
+              failed_when: false
             - import_tasks: tasks/remove_test_interfaces_with_dhcp.yml

--- a/tests/playbooks/tests_bond_options.yml
+++ b/tests/playbooks/tests_bond_options.yml
@@ -188,7 +188,7 @@
                   - name: "{{ controller_profile }}"
                     persistent_state: absent
                     state: down
-              ignore_errors: true
+              failed_when: false
             - command: ip link del {{ controller_device }}
-              ignore_errors: true
+              failed_when: false
             - import_tasks: tasks/remove_test_interfaces_with_dhcp.yml

--- a/tests/playbooks/tests_bond_removal.yml
+++ b/tests/playbooks/tests_bond_removal.yml
@@ -235,9 +235,9 @@
                   - name: "{{ controller_profile }}"
                     state: down
                     persistent_state: absent
-              ignore_errors: true
+              failed_when: false
             - command: ip link del {{ controller_device }}
-              ignore_errors: true
+              failed_when: false
             - import_tasks: tasks/remove_test_interfaces_with_dhcp.yml
             - name: "Restore the /etc/resolv.conf for initscript"
               command: mv -vf /etc/resolv.conf.bak /etc/resolv.conf

--- a/tests/playbooks/tests_checkpoint_cleanup.yml
+++ b/tests/playbooks/tests_checkpoint_cleanup.yml
@@ -74,7 +74,7 @@
       always:
         - tags:
             - "tests::cleanup"
-          ignore_errors: true
+          ignore_errors: true  # noqa ignore-errors
           block:
             # Use internal module directly for speedup
             - network_connections:

--- a/tests/playbooks/tests_eth_pci_address_match.yml
+++ b/tests/playbooks/tests_eth_pci_address_match.yml
@@ -75,4 +75,4 @@
                   - name: pseudo-pci-test-only
                     persistent_state: absent
                     state: down
-              ignore_errors: true
+              failed_when: false

--- a/tests/playbooks/tests_ethtool_coalesce.yml
+++ b/tests/playbooks/tests_ethtool_coalesce.yml
@@ -155,7 +155,7 @@
                 network_connections:
                   - name: "{{ interface }}"
                     persistent_state: absent
-              ignore_errors: true
+              failed_when: false
             - include_tasks: tasks/manage_test_interface.yml
               vars:
                 state: absent

--- a/tests/playbooks/tests_ethtool_features.yml
+++ b/tests/playbooks/tests_ethtool_features.yml
@@ -202,7 +202,7 @@
                   - name: "{{ interface }}"
                     persistent_state: absent
                     state: down
-              ignore_errors: true
+              failed_when: false
             - include_tasks: tasks/manage_test_interface.yml
               vars:
                 state: absent

--- a/tests/playbooks/tests_ethtool_ring.yml
+++ b/tests/playbooks/tests_ethtool_ring.yml
@@ -193,7 +193,7 @@
                 network_connections:
                   - name: "{{ interface }}"
                     persistent_state: absent
-              ignore_errors: true
+              failed_when: false
             - include_tasks: tasks/manage_test_interface.yml
               vars:
                 state: absent

--- a/tests/playbooks/tests_infiniband.yml
+++ b/tests/playbooks/tests_infiniband.yml
@@ -76,6 +76,6 @@
                   - name: ib0-10
                     persistent_state: absent
                     state: down
-              ignore_errors: true
+              failed_when: false
             - command: ip link del ib0.000a
-              ignore_errors: true
+              failed_when: false

--- a/tests/playbooks/tests_ipv6_dns_search.yml
+++ b/tests/playbooks/tests_ipv6_dns_search.yml
@@ -156,4 +156,4 @@
                   - name: br-example
                     persistent_state: absent
                     state: down
-              ignore_errors: true
+              failed_when: false

--- a/tests/playbooks/tests_reapply.yml
+++ b/tests/playbooks/tests_reapply.yml
@@ -59,7 +59,7 @@
       always:
         - tags:
             - "tests::cleanup"
-          ignore_errors: true
+          ignore_errors: true  # noqa ignore-errors
           block:
             # Use internal module directly for speedup
             - network_connections:

--- a/tests/playbooks/tests_wireless.yml
+++ b/tests/playbooks/tests_wireless.yml
@@ -88,5 +88,5 @@
                   - name: "{{ interface }}"
                     persistent_state: absent
                     state: down
-              ignore_errors: true
+              failed_when: false
             - include_tasks: tasks/cleanup_mock_wifi.yml

--- a/tests/tests_change_indication_on_repeat_run.yml
+++ b/tests/tests_change_indication_on_repeat_run.yml
@@ -65,7 +65,7 @@
                   - name: "{{ interface }}"
                     persistent_state: absent
                     state: down
-              ignore_errors: true
+              ignore_errors: true  # noqa ignore-errors
             - include_tasks: tasks/manage_test_interface.yml
               vars:
                 state: absent

--- a/tests/tests_unit.yml
+++ b/tests/tests_unit.yml
@@ -10,7 +10,7 @@
         name: "{{ item }}"
         state: present
       # Ignore error because some package names might not be available
-      ignore_errors: true
+      ignore_errors: true  # noqa ignore-errors
       loop:
         - NetworkManager-libnm
         - python2-gobject-base


### PR DESCRIPTION
In some test playbooks, the `ignore_errors: true` can not be replaced by `changed_when: false`, because `changed_when` is not a valid attribute for a IncludeRole.