### PR TITLE
Fingerprint RHEL System Role managed config files

### DIFF
--- a/templates/get_ansible_managed.j2
+++ b/templates/get_ansible_managed.j2
@@ -1,1 +1,2 @@
 {{ ansible_managed | comment }}
+{{ "system_role:network" | comment(prefix="", postfix="") }}

--- a/tests/tasks/assert_profile_present.yml
+++ b/tests/tasks/assert_profile_present.yml
@@ -10,3 +10,8 @@
   assert:
     that: lsr_net_profile_ansible_managed
     msg: "profile {{ profile }} does not have the ansible managed comment"
+
+- name: Assert that the fingerprint comment is present in {{ profile }}
+  assert:
+    that: lsr_net_profile_fingerprint
+    msg: "profile {{ profile }} does not have the fingerprint comment"

--- a/tests/tasks/get_profile_stat.yml
+++ b/tests/tasks/get_profile_stat.yml
@@ -4,6 +4,7 @@
   set_fact:
     lsr_net_profile_exists: false
     lsr_net_profile_ansible_managed: false
+    lsr_net_profile_fingerprint: false
 
 - name: Stat profile file
   stat:
@@ -28,6 +29,7 @@
   changed_when: false
 
 # lsr_net_profile_ansible_managed:
+# lsr_net_profile_fingerprint:
 # under NetworkManager's control, the comment is not added by design.
 # Thus, set it always to true.
 - name: >-
@@ -36,6 +38,7 @@
   set_fact:
     lsr_net_profile_exists: true
     lsr_net_profile_ansible_managed: true
+    lsr_net_profile_fingerprint: true
   when: nm_profile_exists.rc == 0
 
 - name: Check ansible_managed comment for the initscripts case
@@ -53,5 +56,18 @@
     - name: Verify the ansible_managed comment in ifcfg-{{ profile }}
       set_fact:
         lsr_net_profile_ansible_managed: true
+      when:
+        - _result.stdout_lines | length == 1
+
+    - name: Get the fingerprint comment in ifcfg-{{ profile }}
+      command: >-
+        grep "^# system_role:network"
+        /etc/sysconfig/network-scripts/ifcfg-{{ profile }}
+      register: _result
+      changed_when: false
+
+    - name: Verify the fingerprint comment in ifcfg-{{ profile }}
+      set_fact:
+        lsr_net_profile_fingerprint: true
       when:
         - _result.stdout_lines | length == 1


### PR DESCRIPTION
Add role name to the generated config files.
```
# system_role:network
```
@tyll, @liangwen12year, @cathay4t,
This change is for an RFE described in RHELPLAN-77233. We'd like to have inputs from the network role team before applying this to the other roles. Could you please take a look at the ticket and this pr and share your feedback?
Thanks.