### PR TITLE
Use type coercion when combining `when` statement with `loop`

### DIFF
--- a/tests/tasks/run_test.yml
+++ b/tests/tasks/run_test.yml
@@ -40,7 +40,7 @@
 
     - name: Conditional asserts
       include_tasks: "{{ item['what'] }}"
-      when: item['when']
+      when: item['when'] | bool
       loop: "{{ lsr_assert_when | default([]) }}"
 
     - name: "Success in test '{{ lsr_description }}'"


### PR DESCRIPTION
when using a `when` statement with a `loop`, type may not be compatible. Therefore, use type coercion to make the type compatible.