### PR TITLE
in lsr_assert_when use condition instead of when

### DIFF
--- a/tests/playbooks/tests_states.yml
+++ b/tests/playbooks/tests_states.yml
@@ -31,7 +31,7 @@
               # Device should be present because of autoconnect: true by
               # default for NM (this might be considered a bug)
               - what: tasks/assert_device_present.yml
-                when: network_provider == 'nm'
+                condition: "{{ network_provider == 'nm' }}"
             lsr_cleanup:
               - tasks/cleanup_profile+device.yml
 
@@ -103,7 +103,7 @@
               - tasks/assert_profile_absent.yml
             lsr_assert_when:
               - what: tasks/assert_device_absent.yml
-                when: network_provider == 'nm'
+                condition: "{{ network_provider == 'nm' }}"
             lsr_cleanup:
               - tasks/cleanup_profile+device.yml
 
@@ -128,6 +128,6 @@
               - tasks/get_NetworkManager_NVR.yml
             lsr_assert_when:
               - what: tasks/assert_device_absent.yml
-                when: network_provider == 'nm'
+                condition: "{{ network_provider == 'nm' }}"
             lsr_cleanup:
               - tasks/cleanup_profile+device.yml

--- a/tests/tasks/run_test.yml
+++ b/tests/tasks/run_test.yml
@@ -40,7 +40,7 @@
 
     - name: Conditional asserts
       include_tasks: "{{ item['what'] }}"
-      when: item['when']
+      when: item['condition']
       loop: "{{ lsr_assert_when | default([]) }}"
 
     - name: "Success in test '{{ lsr_description }}'"


### PR DESCRIPTION
ansible-lint is confused by the use of `when:` with `lsr_assert_when`.
It thinks the `when` string should be evaluated as a Jinja expression
but it is really just a plain string.  To make this more friendly to
ansible-lint, use `condition:` instead of `when:` with
`lsr_assert_when`.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
