### PR TITLE
Fix the failure of running ANSIBLE_GATHERING=explicit on tests_switch_provider.yml

### DIFF
--- a/tests/tests_switch_provider.yml
+++ b/tests/tests_switch_provider.yml
@@ -2,6 +2,9 @@
 ---
 - hosts: all
   name: Run playbook 'playbooks/tests_switch_provider.yml'
+  tasks:
+    - name: Include the task 'el_repo_setup.yml'
+      include_tasks: tasks/el_repo_setup.yml
 
 - name: Import the playbook 'playbooks/tests_switch_provider.yml'
   import_playbook: playbooks/tests_switch_provider.yml


### PR DESCRIPTION
The test `tests_switch_provider.yml` does not support running with `ANSIBLE_GATHERING=explicit`. Therefore, include the task 'el_repo_setup.yml' before running the test which supports gathering the minimum subset of facts required.