### PR TITLE
style: Use standard Ansible braces and brackets spacing

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -5,12 +5,6 @@ ignore: |
   /.tox/
   tests/roles/
 rules:
-  braces:
-    level: error
-    max-spaces-inside: 1
-  brackets:
-    level: error
-    max-spaces-inside: 1
   document-start: disable
   line-length:
     ignore: '/tests/tasks/setup_mock_wifi_wpa3_owe.yml

--- a/tests/playbooks/tests_bond_cloned_mac.yml
+++ b/tests/playbooks/tests_bond_cloned_mac.yml
@@ -64,9 +64,9 @@
           ignore_errors: true
           changed_when: false
           loop:
-            - { name: "{{ controller_profile }}", mac: "12:23:34:45:56:60"}
-            - { name: "{{ port1_profile }}", mac: "12:23:34:45:56:61"}
-            - { name: "{{ port2_profile }}", mac: "--"}
+            - {name: "{{ controller_profile }}", mac: "12:23:34:45:56:60"}
+            - {name: "{{ port1_profile }}", mac: "12:23:34:45:56:61"}
+            - {name: "{{ port2_profile }}", mac: "--"}
           when: network_provider == 'nm'
 
         - name: >

--- a/tests/playbooks/tests_bond_options.yml
+++ b/tests/playbooks/tests_bond_options.yml
@@ -92,22 +92,22 @@
           register: result
           until: "'{{ item.value }}' in result.stdout"
           loop:
-            - { key: 'mode', value: '802.3ad'}
-            - { key: 'ad_actor_sys_prio', value: '65535'}
-            - { key: 'ad_actor_system', value: '00:00:5e:00:53:5d'}
-            - { key: 'ad_select', value: 'stable'}
-            - { key: 'ad_user_port_key', value: '1023'}
+            - {key: 'mode', value: '802.3ad'}
+            - {key: 'ad_actor_sys_prio', value: '65535'}
+            - {key: 'ad_actor_system', value: '00:00:5e:00:53:5d'}
+            - {key: 'ad_select', value: 'stable'}
+            - {key: 'ad_user_port_key', value: '1023'}
             # wokeignore:rule=slave
-            - { key: 'all_slaves_active', value: '1'}
-            - { key: 'downdelay', value: '0'}
-            - { key: 'lacp_rate', value: 'slow'}
-            - { key: 'lp_interval', value: '128'}
-            - { key: 'miimon', value: '110'}
-            - { key: 'num_grat_arp', value: '64'}
-            - { key: 'resend_igmp', value: '225'}
-            - { key: 'updelay', value: '0'}
-            - { key: 'use_carrier', value: '1'}
-            - { key: 'xmit_hash_policy', value: 'encap2+3'}
+            - {key: 'all_slaves_active', value: '1'}
+            - {key: 'downdelay', value: '0'}
+            - {key: 'lacp_rate', value: 'slow'}
+            - {key: 'lp_interval', value: '128'}
+            - {key: 'miimon', value: '110'}
+            - {key: 'num_grat_arp', value: '64'}
+            - {key: 'resend_igmp', value: '225'}
+            - {key: 'updelay', value: '0'}
+            - {key: 'use_carrier', value: '1'}
+            - {key: 'xmit_hash_policy', value: 'encap2+3'}
           changed_when: false
 
         - name: "** TEST check IPv4"
@@ -161,11 +161,11 @@
           register: result
           until: "'{{ item.value }}' in result.stdout"
           loop:
-            - { key: 'mode', value: 'active-backup'}
-            - { key: 'arp_interval', value: '60'}
-            - { key: 'arp_ip_target', value: '192.0.2.128'}
-            - { key: 'arp_validate', value: 'none'}
-            - { key: 'primary', value: '{{ dhcp_interface1 }}'}
+            - {key: 'mode', value: 'active-backup'}
+            - {key: 'arp_interval', value: '60'}
+            - {key: 'arp_ip_target', value: '192.0.2.128'}
+            - {key: 'arp_validate', value: 'none'}
+            - {key: 'primary', value: '{{ dhcp_interface1 }}'}
           changed_when: false
 
         - name: "** TEST check IPv4"


### PR DESCRIPTION
Use standard Ansible spacing for braces and brackets.  This
allows us to remove those rule exceptions from .yamllint.yml
