### PR TITLE
style: ansible-lint - fix missing YAML document start

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -5,7 +5,6 @@ ignore: |
   /.tox/
   tests/roles/
 rules:
-  document-start: disable
   line-length:
     ignore: '/tests/tasks/setup_mock_wifi_wpa3_owe.yml
 

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -1,3 +1,4 @@
+---
 - name: Play for setting up snapshots
   hosts: all
   tasks:

--- a/tests/tasks/el_repo_setup.yml
+++ b/tests/tasks/el_repo_setup.yml
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
+---
 - name: Gather the minimum subset of ansible_facts required by the network
     role test
   setup:

--- a/tests/tasks/setup_802.1x.yml
+++ b/tests/tasks/setup_802.1x.yml
@@ -1,3 +1,4 @@
+---
 - name: Include the task 'setup_802_1x_server.yml'
   include_tasks: tasks/setup_802_1x_server.yml
 - name: Copy client certs


### PR DESCRIPTION
ansible-lint requires that YAML documents begin with a line
consisting of `---`

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
