### PR TITLE
feat: Support "no-aaaa" DNS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ The IP configuration supports the following options:
     - `ip6-bytestring`
     - `ip6-dotint`
     - `ndots:n`
+    - `no-aaaa`
     - `no-check-names`
     - `no-ip6-dotint`
     - `no-reload`

--- a/module_utils/network_lsr/argument_validator.py
+++ b/module_utils/network_lsr/argument_validator.py
@@ -843,6 +843,7 @@ class ArgValidator_DictIP(ArgValidatorDict):
         r"^ip6-bytestring$",
         r"^ip6-dotint$",
         r"^ndots:([1-9]\d*|0)$",
+        r"^no-aaaa$",
         r"^no-check-names$",
         r"^no-ip6-dotint$",
         r"^no-reload$",

--- a/tests/playbooks/tests_eth_dns_support.yml
+++ b/tests/playbooks/tests_eth_dns_support.yml
@@ -44,6 +44,7 @@
                 - example.com
                 - example.org
               dns_options:
+                - no-aaaa
                 - rotate
                 - timeout:1
 
@@ -104,8 +105,10 @@
     - name: "Assert that DNS options are configured correctly"
       assert:
         that:
+          - "'no-aaaa' in ipv4_dns.stdout"
           - "'rotate' in ipv4_dns.stdout"
           - "'timeout:1' in ipv4_dns.stdout"
+          - "'no-aaaa' in ipv6_dns.stdout"
           - "'rotate' in ipv6_dns.stdout"
           - "'timeout:1' in ipv6_dns.stdout"
         msg: "DNS options are configured incorrectly"

--- a/tests/unit/test_network_connections.py
+++ b/tests/unit/test_network_connections.py
@@ -4175,6 +4175,9 @@ class TestValidator(Python26CompatTestCase):
         true_testcase_12 = {
             "dns_options": ["use-vc"],
         }
+        true_testcase_13 = {
+            "dns_options": ["no-aaaa"],
+        }
 
         self.assertEqual(
             validator.validate(true_testcase_1)["dns_options"], ["attempts:3"]
@@ -4209,6 +4212,9 @@ class TestValidator(Python26CompatTestCase):
         )
         self.assertEqual(
             validator.validate(true_testcase_12)["dns_options"], ["use-vc"]
+        )
+        self.assertEqual(
+            validator.validate(true_testcase_13)["dns_options"], ["no-aaaa"]
         )
 
     def test_ipv4_dns_without_ipv4_config(self):


### PR DESCRIPTION
reason: The administrator wants to suppress the AAAA queries made by the stub resolver, including AAAA lookups triggered by NSS-based interfaces such as getaddrinfo. Only the DNS lookups are affected.

result: The administrator is able to suppress AAAA queries made by the stub resolver.