### PR TITLE
ci: Use tox-lsr 2.13 for py26

### DIFF
--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -87,4 +87,4 @@ jobs:
       - name: Run py26 tests
         uses: linux-system-roles/lsr-gh-action-py26@1.0.2
         env:
-          TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@3.0.0"
+          TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"


### PR DESCRIPTION
tox-lsr 3.x does not support python 2.6, so use tox-lsr 2.13 for
py26 testing.  This should be fine until we can drop support for
python 2.6

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
