### PR TITLE
fix: facts being gathered unnecessarily

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -132,3 +132,9 @@ __network_required_facts:
   - distribution_version
   - os_family
   - python
+
+# the subsets of ansible_facts that need to be gathered in case any of the
+# facts in required_facts is missing; see the documentation of
+# the 'gather_subset' parameter of the 'setup' module
+__network_required_facts_subsets: "{{ ['!all', '!min'] +
+  __network_required_facts }}"

--- a/tasks/set_facts.yml
+++ b/tasks/set_facts.yml
@@ -2,9 +2,9 @@
 ---
 - name: Ensure ansible_facts used by role are present
   setup:
-    gather_subset: min
-  when: not ansible_facts.keys() | list |
-    intersect(__network_required_facts) == __network_required_facts
+    gather_subset: "{{ __network_required_facts_subsets }}"
+  when: __network_required_facts |
+    difference(ansible_facts.keys() | list) | length > 0
   no_log: true
 
 - name: Check which services are running


### PR DESCRIPTION
Cause: The comparison of the present facts with the required facts is
being done on unsorted lists.

Consequence: The comparison may fail if the only difference is the
order.  Facts are gathered unnecessarily.

Fix: Use `difference` which works no matter what the order is.  Ensure
that the fact gathering subsets used are the absolute minimum required.

Result: The role gathers only the facts it requires, and does
not unnecessarily gather facts.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
