### PR TITLE
fix: Add dhcp client package dependency for initscripts provider

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,6 +86,12 @@ __network_packages_default_initscripts_network_scripts: ["{%
 if ansible_distribution in __network_rh_distros and
     ansible_distribution_major_version is version('7', '<=')
 %}initscripts{% else %}network-scripts{% endif %}"]
+# Initscripts provider requires `/sbin/dhclient` to obtain DHCP address,
+# which is provided by the dhcp client package
+__network_packages_default_initscripts_dhcp_client: ["{%
+if ansible_distribution in __network_rh_distros and
+    ansible_distribution_major_version is version('7', '<=')
+%}dhclient{% else %}dhcp-client{% endif %}"]
 # convert _network_packages_default_initscripts_bridge to an empty list if it
 # contains only the empty string and add it to the default package list
 # |select() filters the list to include only values that evaluate to true
@@ -94,6 +100,7 @@ if ansible_distribution in __network_rh_distros and
 __network_packages_default_initscripts: "{{
 __network_packages_default_initscripts_bridge | select() | list()
 + __network_packages_default_initscripts_network_scripts | select() | list()
++ __network_packages_default_initscripts_dhcp_client | select() | list()
 }}"
 
 

--- a/tests/playbooks/tests_bond.yml
+++ b/tests/playbooks/tests_bond.yml
@@ -2,8 +2,6 @@
 ---
 - name: Play for testing bond connection
   hosts: all
-  tags:
-    - tests::expfail
   vars:
     controller_profile: bond0
     controller_device: nm-bond

--- a/tests/playbooks/tests_bond_cloned_mac.yml
+++ b/tests/playbooks/tests_bond_cloned_mac.yml
@@ -2,8 +2,6 @@
 ---
 - name: Play for testing bond cloned MAC address
   hosts: all
-  tags:
-    - tests::expfail
   vars:
     controller_profile: bond0
     controller_device: nm-bond

--- a/tests/playbooks/tests_bond_deprecated.yml
+++ b/tests/playbooks/tests_bond_deprecated.yml
@@ -2,8 +2,6 @@
 ---
 - name: Play for testing bond device using deprecated 'master' argument
   hosts: all
-  tags:
-    - tests::expfail
   vars:
     controller_profile: bond0
     controller_device: deprecated-bond

--- a/tests/playbooks/tests_bond_options.yml
+++ b/tests/playbooks/tests_bond_options.yml
@@ -2,8 +2,6 @@
 ---
 - name: Play for testing bond options
   hosts: all
-  tags:
-    - tests::expfail
   vars:
     controller_profile: bond0
     controller_device: nm-bond

--- a/tests/playbooks/tests_bond_removal.yml
+++ b/tests/playbooks/tests_bond_removal.yml
@@ -2,8 +2,6 @@
 ---
 - name: Play for testing bond removal
   hosts: all
-  tags:
-    - tests::expfail
   vars:
     controller_profile: bond0
     controller_device: nm-bond

--- a/tests/tasks/enable_epel.yml
+++ b/tests/tasks/enable_epel.yml
@@ -21,6 +21,12 @@
       retries: 6
       delay: 10
 
+    - name: Install yum-utils package
+      package:
+        state: present
+        name: yum-utils
+      when: ansible_distribution_major_version == '7'
+
     - name: Enable EPEL 7
       command: yum-config-manager --enable epel
       when: ansible_distribution_major_version == '7'


### PR DESCRIPTION
Enhancement:
   fix: Add dhcp client package dependency for initscripts provider
Reason:
   Initscripts provider requires `/sbin/dhclient` to obtain DHCP address, which is shipped in dhcp client package. But the managed hosts may not already install the dhcp client package, thus, add it as the dependency package for initscripts provider.

Result:

Issue Tracker Tickets (Jira or BZ if any):
