### PR TITLE
fix: Allow address 0.0.0.0/0 or ::/0 for 'from'/'to' in a routing rule

### DIFF
--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -1243,7 +1243,9 @@ class NMUtil:
                         routing_rule["dport"][0],
                         routing_rule["dport"][1],
                     )
-                if routing_rule["from"]:
+                # In NM, when user specifies `from 0.0.0.0/0`` or `from ::/0` in a
+                # routing rule, NM treats it as if the `from` setting is not specified.
+                if routing_rule["from"] and routing_rule["from"]["prefix"]:
                     NM.IPRoutingRule.set_from(
                         nm_routing_rule,
                         routing_rule["from"]["address"],
@@ -1274,7 +1276,9 @@ class NMUtil:
                     )
                 if routing_rule["table"]:
                     NM.IPRoutingRule.set_table(nm_routing_rule, routing_rule["table"])
-                if routing_rule["to"]:
+                # In NM, when user specifies `to 0.0.0.0/0`` or `to ::/0` in a
+                # routing rule, NM treats it as if the `to` setting is not specified.
+                if routing_rule["to"] and routing_rule["to"]["prefix"]:
                     NM.IPRoutingRule.set_to(
                         nm_routing_rule,
                         routing_rule["to"]["address"],

--- a/module_utils/network_lsr/argument_validator.py
+++ b/module_utils/network_lsr/argument_validator.py
@@ -779,15 +779,27 @@ class ArgValidatorIPRoutingRule(ArgValidatorDict):
                     name,
                     "missing 'table' for the routing rule",
                 )
-
-        if result["from"] is not None:
+        # `from 0.0.0.0/0` means from all IPv4 addresses
+        # `from ::/0` means from all IPv6 addresses
+        # In NM, if `from` property is not specified in a routing rule, NM
+        # still appends `from 0.0.0.0/0` or `from ::/0` to the rule
+        if result["from"] is not None and result["from"]["address"] not in [
+            "0.0.0.0",
+            "::",
+        ]:
             if result["from"]["prefix"] == 0:
                 raise ValidationError(
                     name,
                     "the prefix length for 'from' cannot be zero",
                 )
 
-        if result["to"] is not None:
+        # NM also allows to specify `to 0.0.0.0/0` or `to ::/0` in a routing
+        # rule, but the connection profiles will only show the `from` setting
+        # for the rule
+        if result["to"] is not None and result["to"]["address"] not in [
+            "0.0.0.0",
+            "::",
+        ]:
             if result["to"]["prefix"] == 0:
                 raise ValidationError(
                     name,

--- a/tests/playbooks/tests_routing_rules.yml
+++ b/tests/playbooks/tests_routing_rules.yml
@@ -92,6 +92,10 @@
                   family: ipv4
                   oif: oiftest
                   table: 30400
+                - priority: 30403
+                  from: 0.0.0.0/0
+                  to: 0.0.0.0/0
+                  table: 30400
                 - priority: 30600
                   to: 2001:db8::4/32
                   table: 30600
@@ -99,6 +103,10 @@
                   family: ipv6
                   dport: 128 - 256
                   invert: true
+                  table: 30600
+                - priority: 30602
+                  from: ::/0
+                  to: ::/0
                   table: 30600
                 - priority: 200
                   from: 198.51.100.56/26
@@ -220,6 +228,8 @@
             0.0.0.0/0 iif iiftest table 30400")
           - connection_route_rule.stdout is search("priority 30402 from
             0.0.0.0/0 oif oiftest table 30400")
+          - connection_route_rule.stdout is search("priority 30403 from
+            0.0.0.0/0 table 30400")
           - connection_route_rule.stdout is search("priority 200 from
             198.51.100.56/26 table 200")
         msg: "the specified IPv4 routing rule was not configured in the
@@ -235,6 +245,8 @@
             ::/0 dport 128-256 table 30600") or
             connection_route_rule6.stdout is search("not priority 30601 from
             ::/0 dport 128-256 table 30600")
+          - connection_route_rule6.stdout is search("priority 30602 from
+            ::/0 table 30600")
         msg: "the specified IPv6 routing rule was not configured in the
           connection '{{ interface }}'"
 

--- a/tests/unit/test_network_connections.py
+++ b/tests/unit/test_network_connections.py
@@ -5050,6 +5050,14 @@ class TestValidatorRoutingRules(Python26CompatTestCase):
             self.validator.validate,
             self.test_connections,
         )
+        self.test_connections[0]["ip"]["routing_rule"][0]["from"] = "::/0"
+        self.test_connections[0]["ip"]["routing_rule"][0]["to"] = "::/0"
+        self.validator.validate(self.test_connections)
+
+        self.test_connections[0]["ip"]["routing_rule"][0]["family"] = "ipv4"
+        self.test_connections[0]["ip"]["routing_rule"][0]["from"] = "0.0.0.0/0"
+        self.test_connections[0]["ip"]["routing_rule"][0]["to"] = "0.0.0.0/0"
+        self.validator.validate(self.test_connections)
 
     def test_routing_rule_missing_table(self):
         """


### PR DESCRIPTION


Enhancement:
fix: Allow address 0.0.0.0/0 or ::/0 for 'from'/'to' in a routing rule

Reason:
`from 0.0.0.0/0` means from all IPv4 addresses, `from ::/0` means from all IPv6 addresses. In NM, if `from` property is not specified in a routing rule, NM still appends `from 0.0.0.0/0` or `from ::/0` to the rule. NM also allows to specify `to 0.0.0.0/0` or `to ::/0` in a routing rule, but the connection profiles will only show the `from` setting for the rule.

Result:

Issue Tracker Tickets (Jira or BZ if any):
