### PR TITLE
docs(changelog): Fix wrong format in version 1.13.2 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,44 +22,9 @@ Changelog
 ### Other Changes
 
 - ci: Add markdownlint, test_converting_readme, and build_docs workflows (#630)
-
-  - markdownlint runs against README.md to avoid any issues with
-    converting it to HTML
-  - test_converting_readme converts README.md > HTML and uploads this test
-    artifact to ensure that conversion works fine
-  - build_docs converts README.md > HTML and pushes the result to the
-    docs branch to publish dosc to GitHub pages site.
-  - Fix markdown issues in README.md
-  
-  Signed-off-by: Sergei Petrosian <spetrosi@redhat.com>
-
 - ci: Make badges consistent, run markdownlint all .md files (#631)
-
-  - Consistently generate badges for GH workflows in roles' RHELPLAN-146921
-  - Run markdownlint on all .md files
-  
-  Signed-off-by: Sergei Petrosian <spetrosi@redhat.com>
-
-- docs: Update README.md [citest skip] (#632)
-
-  Enhancement:
-  Updating README.md to reflect some recently added changes or features.
-  
-  Reason:
-  README.md is outdated.
-  
-  Result:
-  Guarantee that README.md  is up to update.
-  
-  Issue Tracker Tickets (Jira or BZ if any):
-
 - ci: Remove badges from README.md prior to converting to HTML (#633)
-
-  - Remove thematic break after badges
-  - Remove badges from README.md prior to converting to HTML
-  
-  Signed-off-by: Sergei Petrosian <spetrosi@redhat.com>
-
+- docs: Update README.md (#632)
 
 [1.13.1] - 2023-07-19
 --------------------


### PR DESCRIPTION
Enhancement:
docs(changelog): Fix wrong format in version 1.13.2

Reason:
The changelog update for version 1.13.2 contains wrongly formatted content which makes the changelog file update inconsistent from previous release.

Result:

Issue Tracker Tickets (Jira or BZ if any):
