### PR TITLE
refactor: get_ostree_data.sh use env shebang - remove from .sanity*

### DIFF
--- a/.github/run_test.sh
+++ b/.github/run_test.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -x
+#!/usr/bin/env bash
 
-set -euo pipefail
+set -euxo pipefail
 
 TEST_SOURCE_DIR="/network-role"
 C8S_CONTAINER_IMAGE="quay.io/linux-system-roles/c8s-network-role"

--- a/.ostree/get_ostree_data.sh
+++ b/.ostree/get_ostree_data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
@@ -28,7 +28,7 @@ if [ "$pkgtype" = testing ]; then
 fi
 
 get_rolepath() {
-    local ostree_dir role rolesdir roles_parent_dir coll_path pth
+    local ostree_dir role rolesdir roles_parent_dir coll_path path
     ostree_dir="$1"
     role="$2"
     roles_parent_dir="$(dirname "$(dirname "$ostree_dir")")"
@@ -51,8 +51,8 @@ get_rolepath() {
         coll_path="${ANSIBLE_COLLECTIONS_PATHS:-}"
     fi
     if [ -n "${coll_path}" ]; then
-        for pth in ${coll_path//:/ }; do
-            for rolesdir in "$pth"/ansible_collections/*/*_system_roles/roles/"$role"/.ostree; do
+        for path in ${coll_path//:/ }; do
+            for rolesdir in "$path"/ansible_collections/*/*_system_roles/roles/"$role"/.ostree; do
                 if [ -d "$rolesdir" ]; then
                     echo "$rolesdir"
                     return 0

--- a/.sanity-ansible-ignore-2.11.txt
+++ b/.sanity-ansible-ignore-2.11.txt
@@ -56,17 +56,12 @@ plugins/modules/network_connections.py validate-modules:no-default-for-required-
 plugins/modules/network_connections.py validate-modules:parameter-list-no-elements
 plugins/modules/network_connections.py validate-modules:parameter-type-not-in-doc
 plugins/modules/network_connections.py validate-modules:undocumented-parameter
-tests/network/covstats shebang!skip
 tests/network/ensure_provider_tests.py compile-2.6!skip
 tests/network/ensure_provider_tests.py compile-2.7!skip
 tests/network/ensure_provider_tests.py compile-3.5!skip
 tests/network/ensure_provider_tests.py future-import-boilerplate!skip
 tests/network/ensure_provider_tests.py metaclass-boilerplate!skip
 tests/network/ensure_provider_tests.py shebang!skip
-tests/network/get_coverage.sh shebang!skip
-tests/network/get_total_coverage.sh shebang!skip
-tests/network/git-pre-commit.sh shebang!skip
-tests/network/git-post-commit.sh shebang!skip
 tests/network/integration/conftest.py future-import-boilerplate!skip
 tests/network/integration/conftest.py metaclass-boilerplate!skip
 tests/network/integration/test_ethernet.py future-import-boilerplate!skip
@@ -76,4 +71,3 @@ tests/network/unit/test_network_connections.py future-import-boilerplate!skip
 tests/network/unit/test_network_connections.py metaclass-boilerplate!skip
 tests/network/unit/test_nm_provider.py future-import-boilerplate!skip
 tests/network/unit/test_nm_provider.py metaclass-boilerplate!skip
-roles/network/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.12.txt
+++ b/.sanity-ansible-ignore-2.12.txt
@@ -68,11 +68,5 @@ plugins/modules/network_state.py validate-modules:import-error
 plugins/modules/network_state.py validate-modules:missing-examples
 plugins/modules/network_state.py validate-modules:missing-gplv3-license
 plugins/modules/network_state.py validate-modules:module-invalid-version-added
-tests/network/covstats shebang!skip
 tests/network/ensure_provider_tests.py shebang!skip
-tests/network/get_coverage.sh shebang!skip
-tests/network/get_total_coverage.sh shebang!skip
-tests/network/git-pre-commit.sh shebang!skip
-tests/network/git-post-commit.sh shebang!skip
 tests/network/merge_coverage.sh shebang!skip
-roles/network/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.13.txt
+++ b/.sanity-ansible-ignore-2.13.txt
@@ -68,11 +68,5 @@ plugins/modules/network_state.py validate-modules:import-error
 plugins/modules/network_state.py validate-modules:missing-examples
 plugins/modules/network_state.py validate-modules:missing-gplv3-license
 plugins/modules/network_state.py validate-modules:module-invalid-version-added
-tests/network/covstats shebang!skip
 tests/network/ensure_provider_tests.py shebang!skip
-tests/network/get_coverage.sh shebang!skip
-tests/network/get_total_coverage.sh shebang!skip
-tests/network/git-pre-commit.sh shebang!skip
-tests/network/git-post-commit.sh shebang!skip
 tests/network/merge_coverage.sh shebang!skip
-roles/network/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.14.txt
+++ b/.sanity-ansible-ignore-2.14.txt
@@ -68,11 +68,5 @@ plugins/modules/network_state.py validate-modules:import-error
 plugins/modules/network_state.py validate-modules:missing-examples
 plugins/modules/network_state.py validate-modules:missing-gplv3-license
 plugins/modules/network_state.py validate-modules:module-invalid-version-added
-tests/network/covstats shebang!skip
 tests/network/ensure_provider_tests.py shebang!skip
-tests/network/get_coverage.sh shebang!skip
-tests/network/get_total_coverage.sh shebang!skip
-tests/network/git-pre-commit.sh shebang!skip
-tests/network/git-post-commit.sh shebang!skip
 tests/network/merge_coverage.sh shebang!skip
-roles/network/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.15.txt
+++ b/.sanity-ansible-ignore-2.15.txt
@@ -68,11 +68,5 @@ plugins/modules/network_state.py validate-modules:import-error
 plugins/modules/network_state.py validate-modules:missing-examples
 plugins/modules/network_state.py validate-modules:missing-gplv3-license
 plugins/modules/network_state.py validate-modules:module-invalid-version-added
-tests/network/covstats shebang!skip
 tests/network/ensure_provider_tests.py shebang!skip
-tests/network/get_coverage.sh shebang!skip
-tests/network/get_total_coverage.sh shebang!skip
-tests/network/git-pre-commit.sh shebang!skip
-tests/network/git-post-commit.sh shebang!skip
 tests/network/merge_coverage.sh shebang!skip
-roles/network/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.9.txt
+++ b/.sanity-ansible-ignore-2.9.txt
@@ -28,17 +28,12 @@ plugins/modules/network_connections.py validate-modules:missing-gplv3-license
 plugins/modules/network_connections.py validate-modules:no-default-for-required-parameter
 plugins/modules/network_connections.py validate-modules:parameter-type-not-in-doc
 plugins/modules/network_connections.py validate-modules:undocumented-parameter
-tests/network/covstats shebang!skip
 tests/network/ensure_provider_tests.py compile-2.6!skip
 tests/network/ensure_provider_tests.py compile-2.7!skip
 tests/network/ensure_provider_tests.py compile-3.5!skip
 tests/network/ensure_provider_tests.py future-import-boilerplate!skip
 tests/network/ensure_provider_tests.py metaclass-boilerplate!skip
 tests/network/ensure_provider_tests.py shebang!skip
-tests/network/get_coverage.sh shebang!skip
-tests/network/get_total_coverage.sh shebang!skip
-tests/network/git-pre-commit.sh shebang!skip
-tests/network/git-post-commit.sh shebang!skip
 tests/network/integration/conftest.py future-import-boilerplate!skip
 tests/network/integration/conftest.py metaclass-boilerplate!skip
 tests/network/integration/test_ethernet.py future-import-boilerplate!skip
@@ -48,4 +43,3 @@ tests/network/unit/test_network_connections.py future-import-boilerplate!skip
 tests/network/unit/test_network_connections.py metaclass-boilerplate!skip
 tests/network/unit/test_nm_provider.py future-import-boilerplate!skip
 tests/network/unit/test_nm_provider.py metaclass-boilerplate!skip
-roles/network/.ostree/get_ostree_data.sh shebang!skip

--- a/tests/covstats
+++ b/tests/covstats
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
 
 if [ "$#" -lt 1 ]

--- a/tests/get_coverage.sh
+++ b/tests/get_coverage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
 
 if [ -n "${DEBUG}" ]

--- a/tests/get_total_coverage.sh
+++ b/tests/get_total_coverage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
 
 set -e

--- a/tests/git-post-commit.sh
+++ b/tests/git-post-commit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
 
 set -euo pipefail

--- a/tests/git-pre-commit.sh
+++ b/tests/git-pre-commit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
 
 set -euo pipefail

--- a/tests/merge_coverage.sh
+++ b/tests/merge_coverage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
 
 if [ -n "${DEBUG}" ]


### PR DESCRIPTION
Use the `#!/usr/bin/env bash` shebang which is ansible-test friendly.
This means we can remove get_ostree_data.sh from the .sanity* files.
This also means we can remove the .sanity* files if we do not need
them otherwise.  Fix other shell scripts to use the friendly shebang
and remove from the .sanity* files.

Rename `pth` to `path` in honor of nscott

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
