### PR TITLE
tests: Fix installing kernel module in Fedora

### DIFF
--- a/tests/tasks/setup_mock_wifi_wpa3_owe.yml
+++ b/tests/tasks/setup_mock_wifi_wpa3_owe.yml
@@ -48,7 +48,7 @@
 - name: Install mac80211_hwsim kernel modules in Fedora
   shell: |
     dnf -y install koji
-    koji download-build --arch=$(uname -p) kernel-modules-internal-$(uname -r)
+    koji download-build --arch=$(uname -m) kernel-modules-internal-$(uname -r)
     dnf -y install kernel-modules*.rpm
   when:
     - ansible_distribution == 'Fedora'

--- a/tests/tasks/setup_mock_wifi_wpa3_sae.yml
+++ b/tests/tasks/setup_mock_wifi_wpa3_sae.yml
@@ -51,7 +51,7 @@
 - name: Install mac80211_hwsim kernel module in Fedora
   shell: |
     dnf -y install koji
-    koji download-build --arch=$(uname -p) kernel-modules-internal-$(uname -r)
+    koji download-build --arch=$(uname -m) kernel-modules-internal-$(uname -r)
     dnf -y install kernel-modules*.rpm
   when:
     - ansible_distribution == 'Fedora'


### PR DESCRIPTION
`uname -m` will show the machine hardware name.

Enhancement:

Reason:

Result:

Issue Tracker Tickets (Jira or BZ if any):
