### PR TITLE
docs: Add MAC VTAP example

### DIFF
--- a/examples/macvtap.yml
+++ b/examples/macvtap.yml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: BSD-3-Clause
+---
+- name: Manage network MAC VTAP
+  hosts: network-test  
+  vars:
+    network_connections:
+      - name: eth0
+        type: ethernet
+        state: up
+        interface_name: eth0
+        ip:
+          address:
+            - 192.168.0.1/24
+
+      # Create a virtual ethernet card bound to eth0
+      - name: veth0
+        type: macvlan
+        state: up
+        parent: eth0
+        macvlan:
+          mode: bridge
+          promiscuous: true
+          tap: true
+        ip:
+          address:
+            - 192.168.1.1/24
+
+  roles:
+    - linux-system-roles.network


### PR DESCRIPTION
Enhancement: Improved Configuration for MAC VTAP

Reason: The current setup process for MAC VTAP lacks a standardized and reusable approach,Currently we are supporting MAC VTAP as "tap": True in macvlan. To address this, this pull request introduces a yml  file, "macvtap.yml", to provide a  structured method for configuring MAC VTAP. This enhancement aims to simplify the setup process and improve the usability of MAC VTAP.

Result: With the addition of the YAML "macvtap.yml" file, users can easily define and modify MAC VTAP settings by modifying this file. This will streamline the configuration process and enable users to customize MAC VTAP according to their specific requirements. 

Issue Tracker Tickets (Jira or BZ if any):  issue #285
