### PR TITLE
tests: Team interface is indeed supported on Fedora

### DIFF
--- a/tests/ensure_provider_tests.py
+++ b/tests/ensure_provider_tests.py
@@ -101,10 +101,7 @@ ibution_major_version | int < 9",
 blackhole, prohibit and unreachable",
     },
     "playbooks/tests_routing_rules.yml": {},
-    # team interface is not supported on Fedora
-    "playbooks/tests_team.yml": {
-        EXTRA_RUN_CONDITION: "ansible_distribution != 'Fedora'",
-    },
+    "playbooks/tests_team.yml": {},
     "playbooks/tests_team_plugin_installation.yml": {},
     # mac80211_hwsim (used for tests_wireless) only seems to be available
     # and working on RHEL/CentOS 7


### PR DESCRIPTION
Enhancement: Enabling testing team interface on Fedora.

Reason: Team interface is indeed supported on Fedora

Result: We can test the team interface on Fedora. 

Issue Tracker Tickets (Jira or BZ if any):
