### PR TITLE
test: improve name text for skipped ostree tests

### DIFF
--- a/tests/playbooks/tests_team_plugin_installation.yml
+++ b/tests/playbooks/tests_team_plugin_installation.yml
@@ -3,9 +3,10 @@
 - name: Play for testing team plugin installation
   hosts: all
   tasks:
-    - name: Check if rpm ostree system - cannot test
-      meta: end_host
-      when: __network_is_ostree | d(false)
+    - name: Check if test can run on ostree systems
+      include_tasks: tasks/ostree_systems_check.yml
+      vars:
+        package: NetworkManager-team
 
     - name: Remove the NetworkManager-team package
       package:

--- a/tests/playbooks/tests_wireless_and_network_restart.yml
+++ b/tests/playbooks/tests_wireless_and_network_restart.yml
@@ -23,10 +23,10 @@
       tags:
         - always
 
-    - name: Cannot test ostree systems because the package can not be removed
-        or installed - 'NetworkManager-wifi'
-      meta: end_host
-      when: __network_is_ostree | d(false)
+    - name: Check if test can run on ostree systems
+      include_tasks: tasks/ostree_systems_check.yml
+      vars:
+        package: NetworkManager-wifi
 
     - name: Test the wifi connection without NetworkManager restarted
       tags:

--- a/tests/playbooks/tests_wireless_plugin_installation.yml
+++ b/tests/playbooks/tests_wireless_plugin_installation.yml
@@ -3,9 +3,10 @@
 - name: Play for testing wireless plugin installation
   hosts: all
   tasks:
-    - name: Check if rpm ostree system - cannot test
-      meta: end_host
-      when: __network_is_ostree | d(false)
+    - name: Check if test can run on ostree systems
+      include_tasks: tasks/ostree_systems_check.yml
+      vars:
+        package: NetworkManager-wifi
 
     - name: Remove the NetworkManager-wifi package
       package:

--- a/tests/tasks/ostree_systems_check.yml
+++ b/tests/tasks/ostree_systems_check.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+---
+- name: Cannot test ostree systems because the package cannot be removed
+    or installed - '{{ package }}'
+  meta: end_host
+  when: __network_is_ostree | d(false)

--- a/tests/tasks/setup_mock_wifi_wpa3_owe.yml
+++ b/tests/tasks/setup_mock_wifi_wpa3_owe.yml
@@ -18,7 +18,11 @@
   block:
     # It is currently too difficult to install the required kernel
     # if using rpm ostree - so just skip this test
-    - name: Check if rpm ostree system - cannot test
+    - name: >-
+        This is an rpm-ostree system. This test cannot be run on such a system.
+        The test wants to install the hostapd package from copr, and install
+        the mac80211_hwsim kernel module. These operations are currently not
+        supported on rpm-ostree systems.
       meta: end_host
       when: __network_is_ostree | d(false)
 

--- a/tests/tasks/setup_mock_wifi_wpa3_sae.yml
+++ b/tests/tasks/setup_mock_wifi_wpa3_sae.yml
@@ -18,7 +18,11 @@
   block:
     # It is currently too difficult to install the required kernel
     # if using rpm ostree - so just skip this test
-    - name: Check if rpm ostree system - cannot test
+    - name: >-
+        This is an rpm-ostree system. This test cannot be run on such a system.
+        The test wants to install the hostapd package from copr, and install
+        the mac80211_hwsim kernel module. These operations are currently not
+        supported on rpm-ostree systems.
       meta: end_host
       when: __network_is_ostree | d(false)
 

--- a/tests/tests_team_nm.yml
+++ b/tests/tests_team_nm.yml
@@ -21,4 +21,3 @@
   import_playbook: playbooks/tests_team.yml
   when:
     - ansible_distribution_major_version != '6'
-    - ansible_distribution != 'Fedora'

--- a/tests/tests_wireless_and_network_restart_nm.yml
+++ b/tests/tests_wireless_and_network_restart_nm.yml
@@ -21,4 +21,3 @@
   import_playbook: playbooks/tests_wireless_and_network_restart.yml
   when:
     - ansible_distribution_major_version != '6'
-    - ansible_distribution != 'Fedora'


### PR DESCRIPTION
Improve the name text for skipped ostree tests to explain
why the test is skipped.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
