### PR TITLE
docs: Add documentation for specifying VLAN ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,14 @@ configuration is supported at the moment.
 #### `type: vlan`
 
 Similar to `controller`, the `parent` references the connection profile in the ansible
-role.
+role. The vlan ID can be specified by using nested vlan setting, the valid vlan ID
+value ranges from 0 to 4094. Here is how to specify the vlan ID:
+
+```yaml
+type: vlan
+vlan:
+  id: 6
+```
 
 #### `type: macvlan`
 


### PR DESCRIPTION
Enhancement Reason: To provide users with clear guidance on how to specify VLAN ID and settings for the "vlan" type, improving usability and clarity in network configuration.

Result: Users can now easily understand and configure VLAN-related settings using the updated documentation, leading to more efficient network setups.

Issue Tracker Tickets (Jira or BZ if any): [#491] 