### PR TITLE
docs: network_connections module is only meant for internal usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1352,6 +1352,13 @@ The `network` role rejects invalid configurations. It is recommended to test the
 with `--check` first. There is no protection against wrong (but valid) configuration.
 Double-check your configuration before applying it.
 
+### network_connections Internal Module
+
+The `network_connections` internal module is intended for internal use or integration
+testing and is not intended for direct external access or use. When this internal
+module is utilized in integration tests, the tasks specified in `tasks/main.yaml`
+are skipped, thereby speeding up the test execution.
+
 ## Compatibility
 
 The `network` role supports the same configuration scheme for both providers (`nm`


### PR DESCRIPTION
Enhancement:Creating Document for the network_connections module
Reason:To guide users and developers  to use the network_connections module only  for internal usage

Result:with the adding of this documentation user and developers will understand No Direct Invocation for   network_connections module,they  should refrain from directly invoking the network_connections module outside of its designated role.

Issue Tracker Tickets (Jira or BZ if any):#292
