### PR TITLE
ci: use tox-lsr 3.3.0 which uses ansible-test 2.17

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip
-          pip install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
+          pip install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
           # If you have additional OS dependency packages e.g. libcairo2-dev
           # then put them in .github/config/ubuntu-requirements.txt, one
           # package per line.

--- a/.sanity-ansible-ignore-2.17.txt
+++ b/.sanity-ansible-ignore-2.17.txt
@@ -1,0 +1,3 @@
+plugins/modules/network_connections.py validate-modules:missing-gplv3-license
+plugins/modules/network_state.py validate-modules:missing-gplv3-license
+tests/network/ensure_provider_tests.py shebang!skip


### PR DESCRIPTION
Upgrade ci tests to use tox-lsr 3.3.0

tox-lsr 3.3.0 uses ansible-test 2.17

Create the ansible-test ignore file for 2.17

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
