### PR TITLE
ci: tox-lsr 3.4.0 - fix py27 tests; move other checks to py310

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -58,7 +58,16 @@ jobs:
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip
-          pip install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          if [ "${{ matrix.pyver_os.ver }}" = 2.7 ]; then
+            # newer virtualenv cannot create python2 venvs
+            # newer tox requires newer virtualenv
+            tox='tox<4.15'
+            virtualenv='virtualenv<20.22.0'
+          else
+            tox=tox
+            virtualenv=virtualenv
+          fi
+          pip install "$tox" "$virtualenv" "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
           # If you have additional OS dependency packages e.g. libcairo2-dev
           # then put them in .github/config/ubuntu-requirements.txt, one
           # package per line.
@@ -73,11 +82,8 @@ jobs:
           toxenvs="py${toxpyver}"
           # NOTE: The use of flake8, pylint, black with specific
           # python envs is arbitrary and must be changed in tox-lsr
-          # We really should either do those checks using the latest
-          # version of python, or in every version of python
           case "$toxpyver" in
-          27) toxenvs="${toxenvs},coveralls,flake8,pylint" ;;
-          36) toxenvs="${toxenvs},coveralls,black" ;;
+          310) toxenvs="${toxenvs},coveralls,flake8,pylint,black" ;;
           *) toxenvs="${toxenvs},coveralls" ;;
           esac
           TOXENV="$toxenvs" lsr_ci_runtox

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 ---
-extends: default
 ignore: |
   /.tox/
   tests/roles/

--- a/examples/eth_with_802_1x.yml
+++ b/examples/eth_with_802_1x.yml
@@ -23,7 +23,7 @@
       copy:
         src: "{{ item }}"
         dest: /etc/pki/tls/{{ item }}
-        mode: 0600
+        mode: "0600"
       with_items:
         - client.key
         - client.pem

--- a/examples/macvtap.yml
+++ b/examples/macvtap.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
 - name: Manage network MAC VTAP
-  hosts: network-test  
+  hosts: network-test
   vars:
     network_connections:
       - name: eth0

--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -2524,11 +2524,11 @@ class Cmd_nm(Cmd):
             % (
                 con.get_id(),
                 con.get_uuid(),
-                "not-active"
-                if not is_active
-                else "is-modified"
-                if is_modified
-                else "force-state-change",
+                (
+                    "not-active"
+                    if not is_active
+                    else "is-modified" if is_modified else "force-state-change"
+                ),
             ),
         )
         self.connections_data_set_changed(idx)
@@ -2784,11 +2784,11 @@ class Cmd_initscripts(Cmd):
                 "up connection %s (%s)"
                 % (
                     name,
-                    "not-active"
-                    if is_active is not True
-                    else "is-modified"
-                    if is_modified
-                    else "force-state-change",
+                    (
+                        "not-active"
+                        if is_active is not True
+                        else "is-modified" if is_modified else "force-state-change"
+                    ),
                 ),
             )
             cmd = "ifup"

--- a/module_utils/network_lsr/argument_validator.py
+++ b/module_utils/network_lsr/argument_validator.py
@@ -477,7 +477,7 @@ class ArgValidatorDict(ArgValidator):
             items = list(value.items())
         except AttributeError:
             raise ValidationError(name, "invalid content is not a dictionary")
-        for (setting, value) in items:
+        for setting, value in items:
             try:
                 validator = self.nested[setting]
             except KeyError:
@@ -493,7 +493,7 @@ class ArgValidatorDict(ArgValidator):
             except ValidationError as e:
                 raise ValidationError(e.name, e.error_message)
             result[setting] = validated_value
-        for (setting, validator) in self.nested.items():
+        for setting, validator in self.nested.items():
             if setting in seen_keys:
                 continue
             if validator.required:
@@ -543,7 +543,7 @@ class ArgValidatorList(ArgValidator):
             value = [s for s in value.split(" ") if s]
 
         result = []
-        for (idx, v) in enumerate(value):
+        for idx, v in enumerate(value):
             if (v is None or v == "") and self.remove_none_or_empty:
                 continue
             try:

--- a/module_utils/network_lsr/ethtool.py
+++ b/module_utils/network_lsr/ethtool.py
@@ -51,7 +51,9 @@ def get_perm_addr(ifname):
         try:
             res = ecmd.tobytes()
         except AttributeError:  # tobytes() is not available in python2
+            # pylint: disable=no-member
             res = ecmd.tostring()
+            # pylint: enable=no-member
         unused, size, perm_addr = struct.unpack("II%is" % MAX_ADDR_LEN, res)
         perm_addr = Util.mac_ntoa(perm_addr[:size])
     except IOError:

--- a/tests/unit/test_network_connections.py
+++ b/tests/unit/test_network_connections.py
@@ -5270,7 +5270,6 @@ class TestValidatorDictBond(Python26CompatTestCase):
         ]
 
     def test_invalid_bond_option_ad(self):
-
         """
         Test the ad bond option restrictions
         """


### PR DESCRIPTION
The latest version of virtualenv does not support creating
python 2.7 virtualenvs.  Change our CI tests to restrict the version
of virtualenv<20.22.0 and tox<4.15 for py27 environments

Move pylint, flake8, and black checks to the py310 environment
which is currently supported by ansible-core 2.17 and its related
checkers such as ansible-lint and ansible-test

pylint now uses ansible-core 2.17 and restricts the version of
pylint to 3.1.0 which is the version used by ansible-test 2.17

Remove `extends: default` for .yamllint.yml.  The latest version
of ansible-lint will automatically incorporate local yamllint
settings unless there is an `extends:`.

The above changes require some fixes to the role code.

For more information, see
https://github.com/linux-system-roles/tox-lsr/pull/168
and
https://github.com/linux-system-roles/tox-lsr/pull/170

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
