### PR TITLE
fix: add support for EL10

### DIFF
--- a/.ostree/packages-runtime-CentOS-10.txt
+++ b/.ostree/packages-runtime-CentOS-10.txt
@@ -1,0 +1,3 @@
+nmstate
+python3-gobject-base
+python3-libnmstate

--- a/.ostree/packages-runtime-RedHat-10.txt
+++ b/.ostree/packages-runtime-RedHat-10.txt
@@ -1,0 +1,3 @@
+nmstate
+python3-gobject-base
+python3-libnmstate

--- a/.ostree/packages-testing-CentOS-10.txt
+++ b/.ostree/packages-testing-CentOS-10.txt
@@ -1,0 +1,4 @@
+ethtool
+NetworkManager
+procps-ng
+systemd-resolved

--- a/.ostree/packages-testing-RedHat-10.txt
+++ b/.ostree/packages-testing-RedHat-10.txt
@@ -1,0 +1,4 @@
+ethtool
+NetworkManager
+procps-ng
+systemd-resolved

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,14 +6,6 @@ galaxy_info:
   company: Red Hat, Inc.
   license: BSD-3-Clause
   min_ansible_version: "2.9"
-  galaxy_tags:
-    - centos
-    - fedora
-    - network
-    - networking
-    - redhat
-    - rhel
-    - system
   platforms:
     - name: Fedora
       versions:
@@ -24,3 +16,16 @@ galaxy_info:
         - "7"
         - "8"
         - "9"
+  galaxy_tags:
+    - centos
+    - el6
+    - el7
+    - el8
+    - el9
+    - el10
+    - fedora
+    - network
+    - networking
+    - redhat
+    - rhel
+    - system

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,21 @@
     - network_state is defined
     - ansible_distribution_major_version | int < 8
 
+- name: Abort applying teaming configuration if the system version
+    of the managed host is EL10 or later
+  fail:
+    msg: >-
+      Teaming is not supported in
+      {{ ansible_distribution }}-{{ ansible_distribution_major_version }} -
+      use bonding instead
+  when:
+    - ansible_distribution_major_version | int > 9
+    - ansible_distribution in __network_rh_distros
+    - network_connections | selectattr("type", "match", "^team$") | list |
+      length > 0 or
+      network_state | selectattr("type", "match", "^team$") | list |
+      length > 0
+
 - name: Check if updates for network packages are available through the DNF
     package manager due to wireless or team interfaces
   dnf:

--- a/tests/ensure_provider_tests.py
+++ b/tests/ensure_provider_tests.py
@@ -101,8 +101,15 @@ ibution_major_version | int < 9",
 blackhole, prohibit and unreachable",
     },
     "playbooks/tests_routing_rules.yml": {},
-    "playbooks/tests_team.yml": {},
-    "playbooks/tests_team_plugin_installation.yml": {},
+    # teaming support dropped in EL10
+    "playbooks/tests_team.yml": {
+        EXTRA_RUN_CONDITION: "ansible_distribution not in ['RedHat', 'CentOS'] or\n      ansible_distr\
+ibution_major_version | int < 10",
+    },
+    "playbooks/tests_team_plugin_installation.yml": {
+        EXTRA_RUN_CONDITION: "ansible_distribution not in ['RedHat', 'CentOS'] or\n      ansible_distr\
+ibution_major_version | int < 10",
+    },
     # mac80211_hwsim (used for tests_wireless) only seems to be available
     # and working on RHEL/CentOS 7
     "playbooks/tests_wireless.yml": {

--- a/tests/tests_team_nm.yml
+++ b/tests/tests_team_nm.yml
@@ -21,3 +21,5 @@
   import_playbook: playbooks/tests_team.yml
   when:
     - ansible_distribution_major_version != '6'
+    - ansible_distribution not in ['RedHat', 'CentOS'] or
+      ansible_distribution_major_version | int < 10

--- a/tests/tests_team_plugin_installation_nm.yml
+++ b/tests/tests_team_plugin_installation_nm.yml
@@ -21,3 +21,5 @@
   import_playbook: playbooks/tests_team_plugin_installation.yml
   when:
     - ansible_distribution_major_version != '6'
+    - ansible_distribution not in ['RedHat', 'CentOS'] or
+      ansible_distribution_major_version | int < 10


### PR DESCRIPTION
According to the Ansible team, support for listing platforms in
role `meta/main.yml` files is being removed.
Instead, they recommend using `galaxy_tags`

https://github.com/ansible/ansible/blob/stable-2.17/changelogs/CHANGELOG-v2.17.rst
"Remove the galaxy_info field platforms from the role templates"
https://github.com/ansible/ansible/issues/82453

Many roles already have tags such as "rhel", "redhat", "centos", and "fedora".
I propose that we ensure all of the system roles have these tags.
Some of our roles support Suse, Debian, Ubuntu, and others.
We should add tags for those e.g. the ssh role already has tags for "debian" and "ubuntu".

In addition - for each version listed under `platforms.EL` - add a tag like `elN`.

Q: Why not use a delimiter between the platform and the version e.g. `el-10`?

This is not allowed by ansible-lint:

```
meta-no-tags: Tags must contain lowercase letters and digits only., invalid: 'el-10'
meta/main.yml:1
```

So we cannot use uppercase letters either.

Q: Why not use our own meta/main.yml field?

No other fields are allowed by ansible-lint:

```
syntax-check[specific]: 'myfield' is not a valid attribute for a RoleMetadata
```

Q: Why not use some other field?

There are no other applicable or suitable fields.

Q: What happens when we want to support versions like `N.M`?

Use the word "dot" instead of "." e.g. `el10dot3`.
Similarly - use "dash" instead of "-".

We do not need tags such as `fedoraall`.
The `fedora` tag implies that the role works on all supported versions of fedora.
Otherwise, use tags such as `fedora40` if the role only supports specific versions.

Teaming support is dropped in EL10.  Provide an error to users who attempt
to use teaming and suggest that they use bonding instead.  Skip teaming
tests on EL10.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
