### PR TITLE
test: fix some Ansible warnings not caught by lint

### DIFF
--- a/tests/playbooks/tests_auto_gateway.yml
+++ b/tests/playbooks/tests_auto_gateway.yml
@@ -51,20 +51,18 @@
       changed_when: false
     - name: "Assert default ipv4 route is present"
       assert:
-        that:
-          - >-
-            "default via 203.0.113.1 dev {{ interface }}"
-            in ipv4_routes.stdout
+        that: __test_str in ipv4_routes.stdout
+      vars:
+        __test_str: default via 203.0.113.1 dev {{ interface }}
     - name: "Get ipv6 routes"
       command: "ip -6 route"
       register: ipv6_route
       changed_when: false
     - name: "Assert default ipv6 route is present"
       assert:
-        that:
-          - >-
-            "default via 2001:db8::1 dev {{ interface }}"
-            in ipv6_route.stdout
+        that: __test_str in ipv6_route.stdout
+      vars:
+        __test_str: default via 2001:db8::1 dev {{ interface }}
       when: network_provider == "nm"
     - name: "TEARDOWN: remove profiles."
       debug:
@@ -119,20 +117,18 @@
       changed_when: false
     - name: "Assert default ipv4 route is absent"
       assert:
-        that:
-          - >-
-            "default via 203.0.113.1 dev {{ interface }}"
-            not in ipv4_routes.stdout
+        that: __test_str not in ipv4_routes.stdout
+      vars:
+        __test_str: default via 203.0.113.1 dev {{ interface }}
     - name: "Get ipv6 routes"
       command: "ip -6 route"
       register: ipv6_route
       changed_when: false
     - name: "Assert default ipv6 route is absent"
       assert:
-        that:
-          - >-
-            "default via 2001:db8::1 dev {{ interface }}"
-            not in ipv6_route.stdout
+        that: __test_str not in ipv6_route.stdout
+      vars:
+        __test_str: default via 2001:db8::1 dev {{ interface }}
       when: network_provider == "nm"
     - name: "TEARDOWN: remove profiles."
       debug:

--- a/tests/playbooks/tests_ethtool_features.yml
+++ b/tests/playbooks/tests_ethtool_features.yml
@@ -30,7 +30,6 @@
         use: "{{ (__network_is_ostree | d(false)) |
           ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
-
     - name: Test ethtool features settings
       block:
         - name: >-
@@ -60,7 +59,6 @@
           assert:
             that:
               - original_ethtool_features.stdout == ethtool_features.stdout
-
 
         - name: >-
             TEST: I can disable gro and tx-tcp-segmentation and enable gso.
@@ -102,7 +100,6 @@
                   'tx-tcp-segmentation: off' in
                   ethtool_features.stdout_lines | map('trim')
 
-
         - name: >-
             TEST: I can enable tx_tcp_segmentation (using underscores).
           debug:
@@ -135,7 +132,6 @@
                   'tx-tcp-segmentation: on' in
                   ethtool_features.stdout_lines | map('trim')
 
-
         - name: I cannot change tx_tcp_segmentation and tx-tcp-segmentation at
                 the same time.
           block:
@@ -166,11 +162,12 @@
             - name: Assert the duplicate key "tx_tcp_segmentation"
                 configuration error happened
               assert:
-                that:
-                  - '{{  "fatal error: configuration error:
-                      connections[0].ethtool.features: duplicate key
-                      ''tx_tcp_segmentation''" in
-                      __network_connections_result.msg }}'
+                that: __test_str in __network_connections_result.msg
+              vars:
+                __test_str: >-
+                  fatal error: configuration error:
+                  connections[0].ethtool.features: duplicate key
+                  'tx_tcp_segmentation'
 
           always:
             - name: Check failure
@@ -179,7 +176,6 @@
             - name: Assert that the result is failure
               assert:
                 that: __network_connections_result.failed
-
 
         - name: "TEST: I can reset features to their original value."
           debug:

--- a/tests/playbooks/tests_ipv6.yml
+++ b/tests/playbooks/tests_ipv6.yml
@@ -75,10 +75,9 @@
             var: ipv6_route.stdout
         - name: Assert default ipv6 route is set
           assert:
-            that:
-              - >-
-                "default via 2001:db8::1 dev {{ interface }}"
-                in ipv6_route.stdout
+            that: __test_str in ipv6_route.stdout
+          vars:
+            __test_str: default via 2001:db8::1 dev {{ interface }}
         - name: Ensure ping6 command is present
           package:
             name: iputils

--- a/tests/playbooks/tests_reapply.yml
+++ b/tests/playbooks/tests_reapply.yml
@@ -61,7 +61,7 @@
         - name: Assert that reapply is found in log output
           assert:
             fail_msg: Reapply not found in log output
-            that: "{{ 'connection reapplied' in test_module_run.stderr }}"
+            that: "'connection reapplied' in test_module_run.stderr"
       always:
         - name: Clean up the test device and the connection profile
           tags:

--- a/tests/tasks/assert_IPv4_present.yml
+++ b/tests/tasks/assert_IPv4_present.yml
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
 - name: "** TEST check IPv4"
-  command: ip -4 a s {{ interface }}
+  command: ip -4 a s {{ interface | quote }}
   register: result
-  until: "'{{ address }}' in result.stdout"
+  until: address in result.stdout
   retries: 20
   delay: 2
   changed_when: false

--- a/tests/tasks/assert_IPv6_present.yml
+++ b/tests/tasks/assert_IPv6_present.yml
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
 - name: "** TEST check IPv6"
-  command: ip -6 a s {{ controller_device }}
+  command: ip -6 a s {{ controller_device | quote }}
   register: result
-  until: "'{{ address }}' in result.stdout"
+  until: address in result.stdout
   retries: 20
   delay: 2
   changed_when: false

--- a/tests/tasks/assert_bond_options.yml
+++ b/tests/tasks/assert_bond_options.yml
@@ -2,10 +2,12 @@
 ---
 - name: "** TEST check bond settings"
   command: cat
-    /sys/class/net/{{ controller_device }}/bonding/'{{ item.key }}'
+    /sys/class/net/{{ controller_device }}/bonding/{{ bond_opt.key | quote }}
   register: result
-  until: "'{{ item.value }}' in result.stdout"
+  until: bond_opt.value in result.stdout
   loop: "{{ bond_options_to_assert }}"
+  loop_control:
+    loop_var: bond_opt
   changed_when: false
 - name: Include the task 'assert_IPv4_present.yml'
   include_tasks: assert_IPv4_present.yml

--- a/tests/tasks/assert_bond_port_profile_present.yml
+++ b/tests/tasks/assert_bond_port_profile_present.yml
@@ -3,8 +3,10 @@
 - name: Include the task 'assert_profile_present.yml'
   include_tasks: tasks/assert_profile_present.yml
   vars:
-    profile: "{{ item }}"
+    profile: "{{ bond_port_profile }}"
   loop:
     - "{{ controller_profile }}"
     - "{{ port1_profile }}"
     - "{{ port2_profile }}"
+  loop_control:
+    loop_var: bond_port_profile


### PR DESCRIPTION
Do not use templating in `when:`, `that:`, `until:`.  These
are evaluated as Jinja statements.  In cases where the string
used is long or awkward to generate in-line, use an
intermediate var for the value.

Use a unique loop var instead of `item` in cases where a loop
may be called in a nested context.

Fix some formatting.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
