### PR TITLE
test: team plugin test does not clean up properly

### DIFF
--- a/tests/playbooks/tests_team_plugin_installation.yml
+++ b/tests/playbooks/tests_team_plugin_installation.yml
@@ -23,17 +23,37 @@
           - "'NetworkManager-team' not in ansible_facts.packages"
         msg: "NetworkManager-team is not removed before team configuration"
 
-    - name: "Team interface configuration"
-      include_role:
-        name: linux-system-roles.network
+    - name: Test the team connection
+      tags:
+        - tests::team:create
       vars:
+        interface: team0
+        profile: "{{ interface }}"
         network_allow_restart: true
         network_connections:
           # Specify the team profile
-          - name: team0
+          - name: "{{ interface }}"
             persistent_state: present
             type: team
-            interface_name: team0
+            interface_name: "{{ interface }}"
+        lsr_fail_debug:
+          - __network_connections_result
+      block:
+        - name: Include the task 'run_test.yml'
+          include_tasks: tasks/run_test.yml
+          vars:
+            lsr_description: Create a team interface without any port attached
+            lsr_setup:
+              - tasks/delete_interface.yml
+              - tasks/assert_device_absent.yml
+            lsr_test:
+              - tasks/create_team_profile.yml
+            lsr_assert:
+              - tasks/assert_profile_present.yml
+              - tasks/assert_device_present.yml
+            lsr_cleanup:
+              - tasks/cleanup_profile+device.yml
+              - tasks/check_network_dns.yml
 
     - name: "Get the rpm package facts"
       package_facts:
@@ -44,7 +64,4 @@
         that:
           - "'NetworkManager-team' in ansible_facts.packages"
         msg: "NetworkManager-team is not installed after team configuration"
-
-    - name: Verify network state restored to default
-      include_tasks: tasks/check_network_dns.yml
 ...


### PR DESCRIPTION
The team plugin test does not clean up properly causing the following team
test to fail.  The fix is to use the network standard run_test.yml interface
to ensure proper preconditions and cleanup for the team plugin test.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>