### PR TITLE
tests: Use EPEL-7 from archive

### DIFF
--- a/tests/tasks/enable_epel.yml
+++ b/tests/tasks/enable_epel.yml
@@ -6,10 +6,17 @@
     - ansible_distribution_major_version in ['7', '8']
   block:
     - name: Create EPEL {{ ansible_distribution_major_version }}
+      vars:
+        __epel_7:
+          "https://dl.fedoraproject.org/pub/archive/epel/7/x86_64/\
+          Packages/e/epel-release-7-14.noarch.rpm"
+        __epel: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{
+            ansible_distribution_major_version }}.noarch.rpm
+        __epel_url: "{{
+          __epel_7 if ansible_distribution_major_version == '7'
+          else __epel }}"
       command:
-        cmd: >-
-          rpm -iv https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{
-          ansible_distribution_major_version }}.noarch.rpm
+        cmd: rpm -iv {{ __epel_url }}
         # noqa command-instead-of-module
         creates: /etc/yum.repos.d/epel.repo
       register: __epel_status


### PR DESCRIPTION
Enhancement:
Fix tests on EL-7

Reason:
EL-7 test were failing due to missing EPEL-7 packages/repository

Result:
EL-7 test should pass

Issue Tracker Tickets (Jira or BZ if any):
#718 