### PR TITLE
test: skip integration pytest on fedora 39 and later

### DIFF
--- a/tests/tests_integration_pytest.yml
+++ b/tests/tests_integration_pytest.yml
@@ -10,4 +10,5 @@
   import_playbook: playbooks/integration_pytest_python3.yml
   when: (ansible_distribution in ["CentOS", "RedHat"] and
         ansible_distribution_major_version == "8") or
-        ansible_distribution == "Fedora"
+        (ansible_distribution == "Fedora" and
+        ansible_distribution_major_version | int < 39)


### PR DESCRIPTION
Something has changed in python, similar to the change between
el8 and el9, that causes the test to fail on f39 and later, so
skip it.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
