### PR TITLE
ci: fix and improve integration container testing

### DIFF
--- a/.github/Dockerfile.c7-network-role
+++ b/.github/Dockerfile.c7-network-role
@@ -1,6 +1,7 @@
 FROM quay.io/centos/centos:centos7
 
-RUN yum -y install epel-release && \
+RUN yum -y install https://dl.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm && \
+    sed -i '/^mirror/d;s/#\?\(baseurl=http:\/\/\)mirror/\1vault/' /etc/yum.repos.d/*.repo && \
     yum -y upgrade && \
     yum -y install NetworkManager NetworkManager-wifi \
     procps-ng iproute ansible openssh-server openssh-clients \

--- a/.github/Dockerfile.c8s-network-role
+++ b/.github/Dockerfile.c8s-network-role
@@ -1,6 +1,7 @@
 FROM quay.io/centos/centos:stream8
 
-RUN dnf -y install dnf-plugins-core epel-release && \
+RUN sed -i '/^mirror/d;s/#\(baseurl=http:\/\/\)mirror/\1vault/' /etc/yum.repos.d/*.repo && \
+    dnf -y install dnf-plugins-core epel-release && \
     dnf config-manager --set-enabled powertools && \
     dnf -y upgrade && \
     dnf -y install NetworkManager NetworkManager-wifi \


### PR DESCRIPTION
Use the vault for centos 7 and centos stream 8

Exclude tests/tests_team_plugin_installation_nm.yml since
tests/tests_team_nm.yml is excluded.

Use grouping to group log lines for better readability.
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#grouping-log-lines

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
