### PR TITLE
test: allow dhcp service if firewall is active

### DIFF
--- a/tests/tasks/create_test_interfaces_with_dhcp.yml
+++ b/tests/tasks/create_test_interfaces_with_dhcp.yml
@@ -120,6 +120,13 @@
         ip link set {{ dhcp_interface1 }}p master testbr
         ip link set {{ dhcp_interface2 }}p master testbr
         # Run joint DHCP4/DHCP6 server with RA enabled in veth namespace
+        if systemctl is-enabled firewalld; then
+            for service in dhcp dhcpv6 dhcpv6-client; do
+                if ! firewall-cmd --query-service="$service"; then
+                    firewall-cmd --add-service "$service"
+                fi
+            done
+        fi
         dnsmasq \
             --pid-file=/run/dhcp_testbr.pid \
             --dhcp-leasefile=/run/dhcp_testbr.lease \

--- a/tests/tasks/remove_test_interfaces_with_dhcp.yml
+++ b/tests/tasks/remove_test_interfaces_with_dhcp.yml
@@ -32,4 +32,11 @@
         service radvd stop
         iptables -D INPUT -i testbr -p udp --dport 67:68 --sport 67:68 -j ACCEPT
     fi
+    if systemctl is-enabled firewalld; then
+        for service in dhcp dhcpv6 dhcpv6-client; do
+            if firewall-cmd --query-service="$service"; then
+                firewall-cmd --remove-service "$service"
+            fi
+        done
+    fi
   changed_when: false


### PR DESCRIPTION
If firewall is active, the dhcp services do not work.  Change the test
to add and remove the dhcp services if firewall is active.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
