### PR TITLE
test: use is-active instead of is-enabled to check for firewalld

### DIFF
--- a/tests/tasks/create_test_interfaces_with_dhcp.yml
+++ b/tests/tasks/create_test_interfaces_with_dhcp.yml
@@ -120,7 +120,7 @@
         ip link set {{ dhcp_interface1 }}p master testbr
         ip link set {{ dhcp_interface2 }}p master testbr
         # Run joint DHCP4/DHCP6 server with RA enabled in veth namespace
-        if systemctl is-enabled firewalld; then
+        if systemctl is-active firewalld; then
             for service in dhcp dhcpv6 dhcpv6-client; do
                 if ! firewall-cmd --query-service="$service"; then
                     firewall-cmd --add-service "$service"

--- a/tests/tasks/remove_test_interfaces_with_dhcp.yml
+++ b/tests/tasks/remove_test_interfaces_with_dhcp.yml
@@ -32,7 +32,7 @@
         service radvd stop
         iptables -D INPUT -i testbr -p udp --dport 67:68 --sport 67:68 -j ACCEPT
     fi
-    if systemctl is-enabled firewalld; then
+    if systemctl is-active firewalld; then
         for service in dhcp dhcpv6 dhcpv6-client; do
             if firewall-cmd --query-service="$service"; then
                 firewall-cmd --remove-service "$service"


### PR DESCRIPTION
Need to test if firewalld is running - the is-active test is
for that, not is-enabled

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
