### PR TITLE
docs: Remove invalid network state example

### DIFF
--- a/examples/network_state_example.yml
+++ b/examples/network_state_example.yml
@@ -19,16 +19,6 @@
       ansible.builtin.include_role:
         name: linux-system-roles.network
 
-    - name: Delete the ethernet device eth1
-      vars:
-        network_state:
-          interfaces:
-            - name: eth1
-              type: ethernet
-              state: absent
-      ansible.builtin.include_role:
-        name: linux-system-roles.network
-
     - name: Bring up the ethernet device eth1
       vars:
         network_state:


### PR DESCRIPTION
For an ethernet device which contains the kernel link, we should not and cannot delete such a device using `network_state` variable.


