### PR TITLE
fix: Prioritize find link info by permanent MAC address, with fallback to current address

### DIFF
--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -226,14 +226,26 @@ class SysUtil:
         if mac is not None:
             mac = Util.mac_norm(mac)
         for linkinfo in cls.link_infos(refresh).values():
-            if mac is not None and mac not in [
-                linkinfo.get("perm-address", None),
-                linkinfo.get("address", None),
-            ]:
-                continue
-            if ifname is not None and ifname != linkinfo.get("ifname", None):
-                continue
-            return linkinfo
+            perm_address = linkinfo.get("perm-address", None)
+            current_address = linkinfo.get("address", None)
+
+            # Match by perm-address (prioritized)
+            if mac is not None and perm_address not in [None, "00:00:00:00:00:00"]:
+                if mac == perm_address:
+                    return linkinfo
+
+            # Fallback to match by address
+            if mac is not None and (perm_address in [None, "00:00:00:00:00:00"]):
+                if mac == current_address:
+                    matched_by_address = linkinfo  # Save for potential fallback
+
+            if ifname is not None and ifname == linkinfo.get("ifname", None):
+                return linkinfo
+
+        # Return fallback match by address if no perm-address match found
+        if "matched_by_address" in locals():
+            return matched_by_address
+
         return None
 
 


### PR DESCRIPTION
Enhancement:
Updated the link_info_find method to prioritize matching links by perm-address when it is valid and available. If the perm-address is unavailable (None or "00:00:00:00:00:00"), the method falls back to matching by address. Additionally, if ifname is provided, it takes precedence and returns the corresponding linkinfo immediately.

Reason:
    The change resolves scenarios where multiple network interfaces might
    share the same current MAC address (address), leading to potential
    ambiguity in link matching. By prioritizing the permanent MAC address
    (perm-address), the method provides a more precise and consistent match.
    This is particularly crucial in environments with:
    
    - MAC address spoofing or dynamic changes, where the current MAC
      address may not reliably identify the interface.
    - Virtual interfaces or VLANs, which often lack a valid perm-address
      and rely on the parent interface's address.
    - Ambiguity when multiple interfaces share the same address.
    
Result:
    This change improves the robustness of MAC address matching by ensuring
    that permanent addresses are prioritized while maintaining a reliable
    fallback mechanism for interfaces with no permanent address.

Issue Tracker Tickets (Jira or BZ if any):
