### PR TITLE
fix: Sort the list of links before fetching the corresponding link infos in sysfs

### DIFF
--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -173,7 +173,7 @@ class SysUtil:
     @staticmethod
     def _link_infos_fetch():
         links = {}
-        for ifname in os.listdir("/sys/class/net/"):
+        for ifname in sorted(os.listdir("/sys/class/net/")):
             if not os.path.islink("/sys/class/net/" + ifname):
                 # /sys/class/net may contain certain entries
                 # that are not interface names, like


### PR DESCRIPTION
Given that a network connection specifies both an interface name and a MAC address for configuring a parent and VLAN connection, and the physical interface has the same permanent and current MAC address, when the configuration is applied multiple times and the role compares the user-specified MAC address against either the "perm-address" (permanent MAC) or "address" (current MAC) from sysfs, treating a match with only the current MAC as valid even if the interface name differs from the user-specified one, then the error “no such interface exists” is raised. The error occurs on the second time the playbook runs where the VLAN device is created and the VLAN device's linkinfo can be extracted from sysfs, but the error is not guaranteed to be raised because The role uses `os.listdir(path)` when collecting the link infos from sysfs. According to the python document
https://docs.python.org/3/library/os.html#os.listdir, the function returns a list containing the names of the entries in the directory given by path and the list is in arbitrary order. The error will only be raised when the VLAN device appears earlier than its parent in the list (the VLAN device is assigned smaller index than its parent in the list). Since the VLAN's device name can be independent of the parent's device name and VLAN ID, to make the behavior deterministic (either guaranteed to raise the error or guaranteed to not raise the error), sort the list of links before fetching the corresponding link infos.

Enhancement:

Reason:

Result:

Issue Tracker Tickets (Jira or BZ if any):
