### PR TITLE
test: add another network interface device for qemu tests

### DIFF
--- a/tests/provision.fmf
+++ b/tests/provision.fmf
@@ -1,0 +1,6 @@
+---
+standard-inventory-qcow2:
+  qemu:
+    # Use qemu-system-x86_64 -net nic,model=help for a list of available devices.
+    net_nic_list:
+      - virtio


### PR DESCRIPTION
The latest version of standard-inventory-qcow2 adds support
for defining multiple network interface devices in the
provision.fmf file.  This is needed for network tests.

https://pagure.io/fork/rmeggins/standard-test-roles/c/4192f757f610fb6e3570806a282c9b744404ce4e?branch=linux-system-roles

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
