### PR TITLE
test: skip initscript related tests on Fedora 41 and later

### DIFF
--- a/tests/ensure_provider_tests.py
+++ b/tests/ensure_provider_tests.py
@@ -84,8 +84,12 @@ ibution_major_version | int < 9",
     "playbooks/tests_provider.yml": {
         MINIMUM_VERSION: "'1.20.0'",
         "comment": "# NetworKmanager 1.20.0 added support for forgetting profiles",
-        EXTRA_RUN_CONDITION: "ansible_distribution not in ['RedHat', 'CentOS'] or\n      ansible_distr\
-ibution_major_version | int < 9",
+        EXTRA_RUN_CONDITION: (
+            "(ansible_distribution == 'Fedora'\n"
+            "       and ansible_distribution_major_version | int < 41)\n"
+            "      or ansible_distribution not in ['RedHat', 'CentOS', 'Fedora']\n"
+            "      or ansible_distribution_major_version | int < 9"
+        ),
     },
     "playbooks/tests_eth_pci_address_match.yml": {
         MINIMUM_VERSION: "'1.26.0'",

--- a/tests/tests_provider_nm.yml
+++ b/tests/tests_provider_nm.yml
@@ -43,5 +43,7 @@
     - ansible_distribution_major_version != '6'
 
     - networkmanager_version is version('1.20.0', '>=')
-    - ansible_distribution not in ['RedHat', 'CentOS'] or
-      ansible_distribution_major_version | int < 9
+    - (ansible_distribution == 'Fedora'
+       and ansible_distribution_major_version | int < 41)
+      or ansible_distribution not in ['RedHat', 'CentOS', 'Fedora']
+      or ansible_distribution_major_version | int < 9

--- a/tests/tests_regression_nm.yml
+++ b/tests/tests_regression_nm.yml
@@ -35,5 +35,7 @@
     - ansible_distribution_major_version != '6'
     # The test depends on behavior that is only visible with newer NM
     - networkmanager_version is version('1.22.0', '>=')
-    - ansible_distribution not in ['RedHat', 'CentOS'] or
+    - ansible_distribution not in ['RedHat', 'CentOS', 'Fedora'] or
+      (ansible_distribution == 'Fedora' and
+       ansible_distribution_major_version | int < 41) or
       ansible_distribution_major_version | int < 9


### PR DESCRIPTION
Support for network-scripts has been removed from Fedora 41
https://discussion.fedoraproject.org/t/f41-change-proposal-removing-network-scripts-package-system-wide/118553
Skip the tests because they fail.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
