### PR TITLE
test: exclude qemu interfaces from dhcp

### DIFF
--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,2 +1,2 @@
 [defaults]
-task_timeout=240
+task_timeout=480

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+task_timeout=240

--- a/tests/tasks/create_test_interfaces_with_dhcp.yml
+++ b/tests/tasks/create_test_interfaces_with_dhcp.yml
@@ -127,11 +127,19 @@
                 fi
             done
         fi
+        # NOTE: When running tests with a qemu managed node, the dhcp
+        # used by qemu interferes with the dhcp used in the test, which
+        # can cause the test to hang.  Exclude the qemu interfaces from
+        # using the test dhcp.  Note that this only affects the qemu tests -
+        # testing farm and other tests with "real" machines will have a
+        # different mac address - the mac addresses used below are specific
+        # to qemu virtual devices.
         dnsmasq \
             --pid-file=/run/dhcp_testbr.pid \
             --dhcp-leasefile=/run/dhcp_testbr.lease \
             --dhcp-range=192.0.2.1,192.0.2.254,240 \
             --dhcp-range=2001:DB8::10,2001:DB8::1FF,slaac,64,240 \
-            --enable-ra --interface=testbr --bind-interfaces
+            --enable-ra --interface=testbr --bind-interfaces \
+            --dhcp-host 52:54:00:12:34:56,ignore --dhcp-host 52:54:00:12:34:57,ignore
     fi
   changed_when: false


### PR DESCRIPTION
When running tests with a qemu managed node, the dhcp
used by qemu interferes with the dhcp used in the test, which
can cause the test to hang.  Exclude the qemu interfaces from
using the test dhcp.  Note that this only affects the qemu tests -
testing farm and other tests with "real" machines will have a
different mac address - the mac addresses used below are specific
to qemu virtual devices.

Also include a tests/ansible.cfg with a task_timeout=240 to kill
any tasks which take longer than 240 seconds, in case there are
still hangs.  This will cause the test to exit with an error.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
