### PR TITLE
test: improve method for finding secondary interface

### DIFF
--- a/tests/playbooks/tests_mac_address_match.yml
+++ b/tests/playbooks/tests_mac_address_match.yml
@@ -18,6 +18,7 @@
     # - `vlan_profile2` (e.g., `120-vlan`) has a fixed name, designed to test a scenario
     #   where lexicographic sorting causes the VLAN to appear before its parent interface.
     default_interface: "{{ lookup('env', 'MAC_ADDR_MATCH_INTERFACE') | default('eth1', true) }}"
+    interfaces_to_check: "{{ [default_interface] + ['eth1', 'ens4', 'ens6'] | unique | list }}"
     profile: "{{ interface }}"
     vlan_profile1: "{{ interface }}.3732"
     vlan_profile2: "120-vlan"
@@ -44,12 +45,18 @@
         executable: /bin/bash
         cmd: |
           set -euxo pipefail
-          for iface in '{{ default_interface }}' ens4; do
+          for iface in {{ interfaces_to_check | join(" ") }}; do
             if ip addr show "$iface" 1>&2; then
+              # interface exists, but may be an alias or altname
+              # find the real name
+              real_iface="$(ip addr show "$iface" | awk -F'[ :]'  '/^[^ ]/ {print $3}')"
               break
             fi
           done
-          echo "$iface"
+          if [ -z "${real_iface:-}" ]; then
+            real_iface=UNKNOWN_DEVICE
+          fi
+          echo "$real_iface"
       changed_when: false
       register: __network_interface_cmd
 


### PR DESCRIPTION
In some cases, the interface given in MAC_ADDR_MATCH_INTERFACE can be an
alias or altname.  The test cannot use the altname, it must use the "real"
interface name.

For example, on some systems, if `MAC_ADDR_MATCH_INTERFACE=enX1`, the test
will fail because it is an altname for `ens4`:

```
+ ip addr show enX1
3: ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 52:54:00:12:34:57 brd ff:ff:ff:ff:ff:ff
    altname enp0s4
    altname enx525400123457
    altname enX1
```

The test will now parse the output of `ip addr show $name` to get the real interface name.

Also, improve the fallback method to look for common secondary interface names
such as eth1 and ens4 in case MAC_ADDR_MATCH_INTERFACE is not one of these.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Improve detection of secondary network interfaces in MAC address match tests to handle alias names and provide common fallbacks.

Tests:
- Introduce a merged `interfaces_to_check` list combining the default interface and common names for lookup
- Update test loop to iterate over all candidate interfaces from `interfaces_to_check`
- Extract the real interface name from `ip addr show` output and default to UNKNOWN_DEVICE if none is found