### PR TITLE
docs(changelog): version 1.17.3 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+[1.17.3] - 2025-07-02
+--------------------
+
+### Other Changes
+
+- ci: bump sclorg/testing-farm-as-github-action from 3 to 4 (#785)
+- ci: bump tox-lsr to 3.8.0; rename qemu/kvm tests (#786)
+- ci: Add Fedora 42; use tox-lsr 3.9.0; use lsr-report-errors for qemu tests (#788)
+- ci: get rid of integration tests - broken, unmaintained (#789)
+- ci: Add support for bootc end-to-end validation tests (#790)
+- ci: Use ansible 2.19 for fedora 42 testing; support python 3.13 (#791)
+- test: improve method for finding secondary interface (#792)
+- refactor: support Ansible 2.19 (#794)
+
 [1.17.2] - 2025-04-23
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.17.3

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Prepare the 1.17.3 release by updating documentation and introducing various CI enhancements, test refinements, and Ansible support refactoring.

Enhancements:
- Refactor support for Ansible 2.19

CI:
- Bump sclorg/testing-farm-as-github-action from v3 to v4
- Upgrade tox-lsr to v3.8.0 and rename QEMU/KVM tests
- Add Fedora 42 support, upgrade to tox-lsr 3.9.0, and integrate lsr-report-errors
- Remove broken and unmaintained integration tests
- Add support for Bootc end-to-end validation tests
- Use Ansible 2.19 for Fedora 42 CI testing and support Python 3.13

Documentation:
- Update CHANGELOG and HTML README for version 1.17.3