### PR TITLE
test: ensure /etc/pki/tls/cert.pem exists for 802 tests on EL10

### DIFF
--- a/tests/playbooks/run_tasks.yml
+++ b/tests/playbooks/run_tasks.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
-- name: Run the tasklist {{ task }}
+- name: Run the tasklist
   hosts: all
   tasks:
     - name: Include the task '{{ task }}'

--- a/tests/playbooks/tests_802_1x.yml
+++ b/tests/playbooks/tests_802_1x.yml
@@ -68,6 +68,16 @@
         - name: Update ca trust
           command: update-ca-trust
           changed_when: false
+        - name: Workaround for EL10 CA trust location
+          shell:
+            cmd: |
+              set -euxo pipefail
+              exec 1>&2
+              if [ ! -f /etc/pki/tls/cert.pem ]; then
+                ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/tls/cert.pem
+              fi
+            executable: /bin/bash
+          changed_when: false
         - name: Import network role
           import_role:
             name: linux-system-roles.network


### PR DESCRIPTION
https://issues.redhat.com/browse/RHEL-87511

The `system_ca_certs: true` flag in NM tells wpa_supplicant to load the
legacy single‑file CA bundle (historically at /etc/pki/tls/cert.pem).
Under CentOS Stream 9 (and RHEL 8), that path existed (either as a file
or a symlink to the bundle), so the default “system” loading worked.

On CentOS Stream 10 (RHEL 10), Red Hat switched to a hashed directory
trust store and removed `/etc/pki/tls/cert.pem` to optimize OpenSSL
performance as indicated in
https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10-beta/html/10.0_beta_release_notes/removed-features
and https://issues.redhat.com/browse/RHEL-50293. wpa_supplicant's
"system_ca_certs" code still tries the old cert.pem path, sees
"No such file or directory" and aborts the TLS setup:

```
OpenSSL: tls_connection_ca_cert - Failed to load root certificates - No such file or directory
EAP‑TLS: Failed to initialize SSL.
```

Hence `system_ca_certs: true` silently fails on Stream 10 because
there is no longer a single‑file CA bundle at that location.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Tests:
- Add Ansible task to symlink the hashed trust store bundle to /etc/pki/tls/cert.pem when missing on EL10