### PR TITLE
test: ensure NetworkManager, ensure eth1 is active

### DIFF
--- a/tests/ensure_provider_tests.py
+++ b/tests/ensure_provider_tests.py
@@ -80,7 +80,10 @@ ibution_major_version | int < 9",
     "playbooks/tests_infiniband.yml": {},
     "playbooks/tests_ipv6_disabled.yml": {},
     "playbooks/tests_ipv6_dns_search.yml": {},
-    "playbooks/tests_mac_address_match.yml": {},
+    "playbooks/tests_mac_address_match.yml": {
+        MINIMUM_VERSION: "'1.18.0'",
+        "comment": "# needs any old version of NM",
+    },
     "playbooks/tests_provider.yml": {
         MINIMUM_VERSION: "'1.20.0'",
         "comment": "# NetworKmanager 1.20.0 added support for forgetting profiles",

--- a/tests/playbooks/tests_mac_address_match.yml
+++ b/tests/playbooks/tests_mac_address_match.yml
@@ -33,6 +33,11 @@
       tags:
         - always
 
+    - name: Ensure NetworkManager is running
+      service:
+        name: NetworkManager
+        state: started
+
     - name: Install ethtool (test dependency)
       package:
         name: ethtool

--- a/tests/tasks/find+remove_profile.yml
+++ b/tests/tasks/find+remove_profile.yml
@@ -1,9 +1,63 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ---
 - name: Get connection profile for '{{ interface }}'
-  command: "nmcli -g GENERAL.CONNECTION device show {{ interface }}"
+  shell:
+    executable: /bin/bash
+    cmd: |
+      set -euo pipefail
+      connection="$(nmcli -g GENERAL.CONNECTION device show {{ interface | quote }})" || :
+      if [ -z "$connection" ]; then
+        nmcli device connect {{ interface | quote }} 1>&2
+      fi
+      nmcli -g GENERAL.CONNECTION device show {{ interface | quote }}
   register: connection_name
   changed_when: false
+
+- name: Debug
+  shell: |
+    set -x
+    exec 1>&2
+    systemctl status NetworkManager || :
+    nmcli || :
+    nmcli device status || :
+    nmcli device show || :
+    nmcli connection show || :
+    nmcli connection show '{{ interface }}' || :
+    ip a
+    echo connection_name: {{ connection_name | to_nice_json | quote }} || :
+    ls -alrtF /etc/sysconfig/network-scripts || :
+    for file in /etc/sysconfig/network-scripts/ifcfg-*; do
+      if [ -f "$file" ]; then
+        echo "file: $file"
+        cat "$file" || :
+      fi
+    done
+    cat /etc/NetworkManager/NetworkManager.conf || :
+    find /etc/NetworkManager -type f -ls || :
+    for file in /etc/NetworkManager/system-connections/*.nmconnection; do
+      if [ -f "$file" ]; then
+        echo "file: $file"
+        cat "$file" || :
+      fi
+    done
+    for file in /etc/NetworkManager/conf.d/*; do
+      if [ -f "$file" ]; then
+        echo "file: $file"
+        cat "$file" || :
+      fi
+    done
+    find /usr/lib/NetworkManager -type f -ls || :
+    for file in /usr/lib/NetworkManager/conf.d/*; do
+      if [ -f "$file" ]; then
+        echo "file: $file"
+        cat "$file" || :
+      fi
+    done
+    NetworkManager --print-config
+    journalctl -u NetworkManager || :
+  changed_when: false
+  when: connection_name is failed or connection_name.stdout | length == 0
+  failed_when: connection_name is failed or connection_name.stdout | length == 0
 
 - name: Bring down and delete the connection profile for '{{ interface }}'
   include_role:

--- a/tests/tests_mac_address_match_nm.yml
+++ b/tests/tests_mac_address_match_nm.yml
@@ -14,10 +14,32 @@
       tags:
         - always
 
+    - name: Install NetworkManager and get NetworkManager version
+      when:
+        - ansible_distribution_major_version != '6'
+      tags:
+        - always
+      block:
+        - name: Install NetworkManager
+          package:
+            name: NetworkManager
+            state: present
+            use: "{{ (__network_is_ostree | d(false)) |
+                     ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
+        - name: Get package info
+          package_facts:
+        - name: Get NetworkManager version
+          set_fact:
+            networkmanager_version: "{{
+              ansible_facts.packages['NetworkManager'][0]['version'] }}"
+
 
 # The test requires or should run with NetworkManager, therefore it cannot run
 # on RHEL/CentOS 6
+# needs any old version of NM
 - name: Import the playbook 'playbooks/tests_mac_address_match.yml'
   import_playbook: playbooks/tests_mac_address_match.yml
   when:
     - ansible_distribution_major_version != '6'
+
+    - networkmanager_version is version('1.18.0', '>=')


### PR DESCRIPTION
This is mainly needed on el7 - NetworkManager is installed by default, or
somewhere else, on el8 and later.

Additionally, if the NetworkManager-server-config package is installed, then
the secondary interface will not be active, so ensure it is active.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Ensure NetworkManager is installed, running, and at a sufficient version for the MAC address match tests and update test configurations accordingly

Tests:
- Install NetworkManager, gather its version, and start its service in the MAC address match test playbook
- Add a condition to require NetworkManager version >= 1.18.0 before running the MAC address match test
- Update the minimum supported NetworkManager version to 1.18.0 in the provider tests configuration