### PR TITLE
test: skip 802_1x tests on el7, RHEL other than 8

### DIFF
--- a/tests/ensure_provider_tests.py
+++ b/tests/ensure_provider_tests.py
@@ -65,12 +65,18 @@ MINIMUM_VERSION = "minimum_version"
 EXTRA_RUN_CONDITION = "extra_run_condition"
 NM_ONLY_TESTS = {
     "playbooks/tests_802_1x_updated.yml": {
-        EXTRA_RUN_CONDITION: "ansible_distribution != 'RedHat' or\n      ansible_distr\
-ibution_major_version | int < 9",
+        EXTRA_RUN_CONDITION: (
+            "(ansible_distribution != 'RedHat' and\n"
+            "       ansible_distribution_major_version | int > 7) or\n"
+            "      ansible_distribution_major_version | int == 8"
+        ),
     },
     "playbooks/tests_802_1x.yml": {
-        EXTRA_RUN_CONDITION: "ansible_distribution != 'RedHat' or\n      ansible_distr\
-ibution_major_version | int < 9",
+        EXTRA_RUN_CONDITION: (
+            "(ansible_distribution != 'RedHat' and\n"
+            "       ansible_distribution_major_version | int > 7) or\n"
+            "      ansible_distribution_major_version | int == 8"
+        ),
     },
     "playbooks/tests_ignore_auto_dns.yml": {},
     "playbooks/tests_bond_options.yml": {},

--- a/tests/tests_802_1x_nm.yml
+++ b/tests/tests_802_1x_nm.yml
@@ -21,5 +21,6 @@
   import_playbook: playbooks/tests_802_1x.yml
   when:
     - ansible_distribution_major_version != '6'
-    - ansible_distribution != 'RedHat' or
-      ansible_distribution_major_version | int < 9
+    - (ansible_distribution != 'RedHat' and
+       ansible_distribution_major_version | int > 7) or
+      ansible_distribution_major_version | int == 8

--- a/tests/tests_802_1x_updated_nm.yml
+++ b/tests/tests_802_1x_updated_nm.yml
@@ -21,5 +21,6 @@
   import_playbook: playbooks/tests_802_1x_updated.yml
   when:
     - ansible_distribution_major_version != '6'
-    - ansible_distribution != 'RedHat' or
-      ansible_distribution_major_version | int < 9
+    - (ansible_distribution != 'RedHat' and
+       ansible_distribution_major_version | int > 7) or
+      ansible_distribution_major_version | int == 8


### PR DESCRIPTION
802_1x tests are only supported on EL8 and later,
and RHEL only on 8.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Enhancements:
- Restrict 802_1x tests to only run on EL8+ and RHEL8 by updating skip conditions in both ensure_provider_tests and test playbooks