### PR TITLE
fix: allow use of built-in routing tables

### DIFF
--- a/module_utils/network_lsr/argument_validator.py
+++ b/module_utils/network_lsr/argument_validator.py
@@ -2771,6 +2771,11 @@ class IPRouteUtils(object):
     def get_route_tables_mapping(cls):
         if not hasattr(cls, "_cached_rt_tables"):
             mapping = {}
+            # look in static built-in route tables file first
+            cls._parse_route_tables_mapping_from_file(
+                "/usr/share/iproute2/rt_tables", mapping
+            )
+            # then look in the user-defined route tables file
             cls._parse_route_tables_mapping_from_file(
                 "/etc/iproute2/rt_tables", mapping
             )

--- a/tests/playbooks/tests_route_table.yml
+++ b/tests/playbooks/tests_route_table.yml
@@ -49,6 +49,11 @@
                   metric: 50
                   table: 30200
                   src: 198.51.100.3
+                - network: 198.51.101.128
+                  prefix: 26
+                  gateway: 198.51.101.1
+                  metric: 2
+                  table: main
 
     - name: Get the routes from the route table 30200
       command: ip route show table 30200
@@ -59,6 +64,12 @@
     - name: Get the routes from the route table 30400
       command: ip route show table 30400
       register: route_table_30400
+      ignore_errors: true
+      changed_when: false
+
+    - name: Get the routes from the route table main
+      command: ip route show table main
+      register: route_table_main
       ignore_errors: true
       changed_when: false
 
@@ -79,6 +90,14 @@
           - route_table_30400.stdout is search("198.51.100.128/26 via
             198.51.100.1 dev ethtest0 proto static metric 2")
         msg: "the route table 30400 does not exist or does not contain the
+          specified route"
+
+    - name: Assert that the route table main contains the specified route
+      assert:
+        that:
+          - route_table_main.stdout is search("198.51.101.128/26 via
+            198.51.101.1 dev ethtest0 proto static metric 2")
+        msg: "the route table main does not exist or does not contain the
           specified route"
 
     - name: Create a dedicated test file in `/etc/iproute2/rt_tables.d/` and
@@ -121,6 +140,11 @@
                   metric: 50
                   table: custom
                   src: 198.51.100.3
+                - network: 198.51.101.128
+                  prefix: 26
+                  gateway: 198.51.101.1
+                  metric: 2
+                  table: custom
 
     - name: Get the routes from the named route table 'custom'
       command: ip route show table custom
@@ -139,6 +163,8 @@
           - route_table_custom.stdout is search("192.0.2.64/26 via
             198.51.100.8 dev ethtest0 proto static src 198.51.100.3
             metric 50")
+          - route_table_custom.stdout is search("198.51.101.128/26 via
+            198.51.101.1 dev ethtest0 proto static metric 2")
         msg: "the named route table 'custom' does not exist or does not contain
           the specified route"
 


### PR DESCRIPTION
Cause: The user is trying to specify the routing table to use by the name of
a built-in routing table defined in /usr/share/iproute2/rt_tables such as `main`.

Consequence: The network role gives an error:
"cannot find route table main in `/etc/iproute2/rt_tables` or `/etc/iproute2/rt_tables.d/`"
The workaround is that the user must specify the table by number instead of name e.g
`table: 254` instead of `table: main`

Fix: Look for table mappings in /usr/share/iproute2/rt_tables as well as the other
paths.

Result: The user can use built-in route table names.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Enable specifying built-in route tables by name by loading mappings from the system rt_tables file and validate the behavior with new tests

Bug Fixes:
- Allow using built-in routing tables by name by parsing /usr/share/iproute2/rt_tables

Enhancements:
- Extend route table mapping lookup order to include system-defined tables before user-defined ones

Tests:
- Add tests to verify route addition and retrieval for built-in and custom routing tables