### PR TITLE
docs(changelog): version 1.17.6 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 Changelog
 =========
 
+[1.17.6] - 2025-10-21
+--------------------
+
+### Bug Fixes
+
+- fix: allow use of built-in routing tables (#804)
+- fix: Skip the loopback profile when deleting all profiles except the ones explicitly included (#813)
+
+### Other Changes
+
+- test: ensure NetworkManager, ensure eth1 is active (#801)
+- test: skip 802_1x tests on el7, RHEL other than 8 (#802)
+- ci: bump actions/checkout from 4 to 5 (#803)
+- ci: rollout several recent changes to CI testing (#806)
+- ci: support openSUSE Leap in qemu/kvm test matrix (#808)
+- ci: use the new epel feature to enable EPEL for testing farm (#809)
+- ci: use tox-lsr 3.12.0 for osbuild_config.yml feature (#811)
+- ci: use JSON format for __bootc_validation (#812)
+- remove wen from CODEOWNERS (#815)
+- ci: bump actions/setup-python from 5 to 6 (#816)
+- ci: bump actions/github-script from 7 to 8 (#817)
+
 [1.17.5] - 2025-08-01
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.17.6

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update changelog and release documentation for version 1.17.6 with bug fixes, test and CI enhancements, and cleanup of CODEOWNERS.

Bug Fixes:
- Allow use of built-in routing tables
- Skip the loopback profile when deleting all profiles except those explicitly included

Enhancements:
- Adjust test suite to ensure NetworkManager and eth1 are active and skip 802.1x tests on EL7 and RHEL <8
- Bump GitHub Actions and tooling versions and extend CI support (openSUSE Leap, EPEL feature, tox-lsr, JSON validation)
- Remove "wen" entry from CODEOWNERS