### PR TITLE
ci: bump tox-lsr to 3.14.0 - this moves standard-inventory-qcow2 to tox-lsr

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.13.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.14.0"
 
       - name: Convert role to collection format
         id: collection

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.13.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.14.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.13.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.14.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -67,7 +67,7 @@ jobs:
             tox=tox
             virtualenv=virtualenv
           fi
-          pip install "$tox" "$virtualenv" "git+https://github.com/linux-system-roles/tox-lsr@3.13.0"
+          pip install "$tox" "$virtualenv" "git+https://github.com/linux-system-roles/tox-lsr@3.14.0"
           # If you have additional OS dependency packages e.g. libcairo2-dev
           # then put them in .github/config/ubuntu-requirements.txt, one
           # package per line.

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -107,7 +107,7 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.13.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.14.0"
 
       # HACK: Drop this when moving this workflow to 26.04 LTS
       - name: Update podman to 5.x for compatibility with bootc-image-builder's podman 5


### PR DESCRIPTION
Previously, CI would download the standard-inventory-qcow2 script from pagure.  However,
the pagure download url is now being protected by Anubis which by default
will check the User-Agent header and deny attempts from clients that look
like scrapers or hackers. Rather than trying to play arms race with setting
headers, etc. - just move this script to tox-lsr. If we really need to sync
with the upstream development, we can do that manually.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update CI configurations to use tox-lsr 3.14.0, eliminating the need to download the standard-inventory-qcow2 script externally

Enhancements:
- Incorporate standard-inventory-qcow2 into tox-lsr by upgrading to version 3.14.0

CI:
- Bump tox-lsr from 3.13.0 to 3.14.0 in all GitHub Actions workflows (ansible-lint, ansible-managed-var-comment, ansible-test, python-unit-test, qemu-kvm-integration-tests)