### PR TITLE
docs(changelog): version 1.17.7 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 Changelog
 =========
 
+[1.17.7] - 2025-11-17
+--------------------
+
+### Bug Fixes
+
+- fix: cannot use community-general version 12 - no py27 and py36 support (#824)
+
+### Other Changes
+
+- ci: bump actions/upload-artifact from 4 to 5 (#819)
+- ci: bump github/codeql-action from 3 to 4 (#820)
+- ci: use versioned upload-artifact instead of master; bump codeql-action to v4; bump upload-artifact to v5 (#821)
+- ci: bump tox-lsr to 3.13.0 (#822)
+- ci: bump tox-lsr to 3.14.0 - this moves standard-inventory-qcow2 to tox-lsr (#823)
+
 [1.17.6] - 2025-10-21
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.17.7

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Prepare release 1.17.7 by updating documentation, fixing community-general version compatibility, and bumping CI dependencies

Bug Fixes:
- Fix compatibility issue with community-general version 12 lacking py27 and py36 support

CI:
- Bump actions/upload-artifact to v5
- Bump github/codeql-action to v4
- Use versioned upload-artifact instead of master
- Bump tox-lsr to 3.13.0 and 3.14.0

Documentation:
- Update CHANGELOG.md and README.html for version 1.17.7