### PR TITLE
Docs: Added routing table example and Fixes #536

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,21 @@ The IP configuration supports the following options:
   source IP address for a route. `table` supports both the numeric table and named
   table. In order to specify the named table, the users have to ensure the named table
   is properly defined in `/etc/iproute2/rt_tables` or
-  `/etc/iproute2/rt_tables.d/*.conf`. The optional `type` key supports the values
+  `/etc/iproute2/rt_tables.d/*.conf`.The network role does not create these routing table entries automatically.
+  You can use the `ansible.builtin.lineinfile` module in your playbook to
+  define the named tables before applying the network role:
+  ```yaml
+  - name: Ensure custom routing tables are defined
+    ansible.builtin.lineinfile:
+      path: /etc/iproute2/rt_tables
+      regexp: '^{{ item.table_id }}\s'
+      line: "{{ item.table_id }}\t{{ item.name }}"
+    loop:
+      - { table_id: 100, name: mytable1 }
+      - { table_id: 101, name: mytable2 }
+    become: true
+  ```
+  The optional `type` key supports the values
   `blackhole`, `prohibit`, and `unreachable`.
   See [man 8 ip-route](https://man7.org/linux/man-pages/man8/ip-route.8.html#DESCRIPTION)
   for their definition. Routes with these types do not support a gateway. If the type
@@ -685,6 +699,20 @@ The IP configuration supports the following options:
       numeric table and named table. In order to specify the named table, the users
       have to ensure the named table is properly defined in `/etc/iproute2/rt_tables`
       or `/etc/iproute2/rt_tables.d/*.conf`.
+      The network role does not create these routing table entries automatically.
+      You can use the `ansible.builtin.lineinfile` module in your playbook to
+      define the named tables before applying the network role:
+      ```yaml
+      - name: Ensure custom routing tables are defined
+        ansible.builtin.lineinfile:
+          path: /etc/iproute2/rt_tables
+          regexp: '^{{ item.table_id }}\s'
+          line: "{{ item.table_id }}\t{{ item.name }}"
+        loop:
+          - { table_id: 100, name: mytable1 }
+          - { table_id: 101, name: mytable2 }
+        become: true
+      ```
   - `to` -
       The destination address of the packet to match (e.g. `192.168.100.58/24`).
   - `tos` -
@@ -1503,6 +1531,12 @@ play in a pre-configure step, and a second step to activate the new configuratio
 In general, to successfully run the play, determine which configuration is
 active in the first place, and then carefully configure a sequence of steps to change to
 the new configuration. The actual solution depends strongly on your environment.
+
+Routing rules and named routing tables are not supported when using the
+`initscripts` provider. If `network_provider: initscripts` is set, any
+`routing_rule` entries and named `table` references in `route` will be
+silently ignored. Use `network_provider: nm` (NetworkManager) for routing
+rule support.
 
 ### Handling potential problems
 

--- a/README.md
+++ b/README.md
@@ -632,19 +632,18 @@ The IP configuration supports the following options:
   source IP address for a route. `table` supports both the numeric table and named
   table. In order to specify the named table, the users have to ensure the named table
   is properly defined in `/etc/iproute2/rt_tables` or
-  `/etc/iproute2/rt_tables.d/*.conf`.The network role does not create these routing table entries automatically.
+  `/etc/iproute2/rt_tables.d/*.conf` .The network role does not create these routing table entries automatically.
   You can use the `ansible.builtin.lineinfile` module in your playbook to
   define the named tables before applying the network role:
   ```yaml
   - name: Ensure custom routing tables are defined
-    ansible.builtin.lineinfile:
-      path: /etc/iproute2/rt_tables
-      regexp: '^{{ item.table_id }}\s'
-      line: "{{ item.table_id }}\t{{ item.name }}"
-    loop:
-      - { table_id: 100, name: mytable1 }
-      - { table_id: 101, name: mytable2 }
-    become: true
+  ansible.builtin.copy:
+    dest: /etc/iproute2/rt_tables.d/{{ item.name }}.conf
+    content: "{{ item.table_id }}\t{{ item.name }}\n"
+  loop:
+    - { table_id: 100, name: mytable1 }
+    - { table_id: 101, name: mytable2 }
+  become: true
   ```
   The optional `type` key supports the values
   `blackhole`, `prohibit`, and `unreachable`.
@@ -698,20 +697,19 @@ The IP configuration supports the following options:
       The route table to look up for the `to-table` action. `table` supports both the
       numeric table and named table. In order to specify the named table, the users
       have to ensure the named table is properly defined in `/etc/iproute2/rt_tables`
-      or `/etc/iproute2/rt_tables.d/*.conf`.
+      or `/etc/iproute2/rt_tables.d/*.conf` .
       The network role does not create these routing table entries automatically.
       You can use the `ansible.builtin.lineinfile` module in your playbook to
       define the named tables before applying the network role:
       ```yaml
-      - name: Ensure custom routing tables are defined
-        ansible.builtin.lineinfile:
-          path: /etc/iproute2/rt_tables
-          regexp: '^{{ item.table_id }}\s'
-          line: "{{ item.table_id }}\t{{ item.name }}"
-        loop:
-          - { table_id: 100, name: mytable1 }
-          - { table_id: 101, name: mytable2 }
-        become: true
+      -  name: Ensure custom routing tables are defined
+      ansible.builtin.copy:
+        dest: /etc/iproute2/rt_tables.d/{{ item.name }}.conf
+        content: "{{ item.table_id }}\t{{ item.name }}\n"
+      loop:
+        - { table_id: 100, name: mytable1 }
+        - { table_id: 101, name: mytable2 }
+      become: true
       ```
   - `to` -
       The destination address of the packet to match (e.g. `192.168.100.58/24`).

--- a/README.md
+++ b/README.md
@@ -633,7 +633,7 @@ The IP configuration supports the following options:
   table. In order to specify the named table, the users have to ensure the named table
   is properly defined in `/etc/iproute2/rt_tables` or
   `/etc/iproute2/rt_tables.d/*.conf` .The network role does not create these routing table entries automatically.
-  You can use the `ansible.builtin.lineinfile` module in your playbook to
+  You can use the `ansible.builtin.copy` module in your playbook to
   define the named tables before applying the network role:
   ```yaml
   - name: Ensure custom routing tables are defined

--- a/README.md
+++ b/README.md
@@ -699,7 +699,7 @@ The IP configuration supports the following options:
       have to ensure the named table is properly defined in `/etc/iproute2/rt_tables`
       or `/etc/iproute2/rt_tables.d/*.conf` .
       The network role does not create these routing table entries automatically.
-      You can use the `ansible.builtin.lineinfile` module in your playbook to
+      You can use the `ansible.builtin.copy` module in your playbook to
       define the named tables before applying the network role:
       ```yaml
       -  name: Ensure custom routing tables are defined

--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ The IP configuration supports the following options:
   source IP address for a route. `table` supports both the numeric table and named
   table. In order to specify the named table, the users have to ensure the named table
   is properly defined in `/etc/iproute2/rt_tables` or
-  `/etc/iproute2/rt_tables.d/*.conf` .The network role does not create these routing table entries automatically.
+  `/etc/iproute2/rt_tables.d/*.conf`. The network role does not create these routing table entries automatically.
   You can use the `ansible.builtin.copy` module in your playbook to
   define the named tables before applying the network role:
   ```yaml

--- a/README.md
+++ b/README.md
@@ -697,7 +697,7 @@ The IP configuration supports the following options:
       The route table to look up for the `to-table` action. `table` supports both the
       numeric table and named table. In order to specify the named table, the users
       have to ensure the named table is properly defined in `/etc/iproute2/rt_tables`
-      or `/etc/iproute2/rt_tables.d/*.conf`. 
+      or `/etc/iproute2/rt_tables.d/*.conf`.
       The network role does not create these routing table entries automatically.
       You can use the `ansible.builtin.copy` module in your playbook to
       define the named tables before applying the network role:

--- a/README.md
+++ b/README.md
@@ -697,7 +697,7 @@ The IP configuration supports the following options:
       The route table to look up for the `to-table` action. `table` supports both the
       numeric table and named table. In order to specify the named table, the users
       have to ensure the named table is properly defined in `/etc/iproute2/rt_tables`
-      or `/etc/iproute2/rt_tables.d/*.conf` .
+      or `/etc/iproute2/rt_tables.d/*.conf`. 
       The network role does not create these routing table entries automatically.
       You can use the `ansible.builtin.copy` module in your playbook to
       define the named tables before applying the network role:

--- a/README.md
+++ b/README.md
@@ -702,14 +702,14 @@ The IP configuration supports the following options:
       You can use the `ansible.builtin.copy` module in your playbook to
       define the named tables before applying the network role:
       ```yaml
-      -  name: Ensure custom routing tables are defined
-         ansible.builtin.copy:
-           dest: /etc/iproute2/rt_tables.d/{{ item.name }}.conf
-           content: "{{ item.table_id }}\t{{ item.name }}\n"
-         loop:
-           - { table_id: 100, name: mytable1 }
-           - { table_id: 101, name: mytable2 }
-         become: true
+      - name: Ensure custom routing tables are defined
+        ansible.builtin.copy:
+          dest: /etc/iproute2/rt_tables.d/{{ item.name }}.conf
+          content: "{{ item.table_id }}\t{{ item.name }}\n"
+        loop:
+          - { table_id: 100, name: mytable1 }
+          - { table_id: 101, name: mytable2 }
+        become: true
       ```
   - `to` -
       The destination address of the packet to match (e.g. `192.168.100.58/24`).

--- a/README.md
+++ b/README.md
@@ -703,13 +703,13 @@ The IP configuration supports the following options:
       define the named tables before applying the network role:
       ```yaml
       -  name: Ensure custom routing tables are defined
-      ansible.builtin.copy:
-        dest: /etc/iproute2/rt_tables.d/{{ item.name }}.conf
-        content: "{{ item.table_id }}\t{{ item.name }}\n"
-      loop:
-        - { table_id: 100, name: mytable1 }
-        - { table_id: 101, name: mytable2 }
-      become: true
+         ansible.builtin.copy:
+           dest: /etc/iproute2/rt_tables.d/{{ item.name }}.conf
+           content: "{{ item.table_id }}\t{{ item.name }}\n"
+         loop:
+           - { table_id: 100, name: mytable1 }
+           - { table_id: 101, name: mytable2 }
+         become: true
       ```
   - `to` -
       The destination address of the packet to match (e.g. `192.168.100.58/24`).

--- a/README.md
+++ b/README.md
@@ -637,13 +637,13 @@ The IP configuration supports the following options:
   define the named tables before applying the network role:
   ```yaml
   - name: Ensure custom routing tables are defined
-  ansible.builtin.copy:
-    dest: /etc/iproute2/rt_tables.d/{{ item.name }}.conf
-    content: "{{ item.table_id }}\t{{ item.name }}\n"
-  loop:
-    - { table_id: 100, name: mytable1 }
-    - { table_id: 101, name: mytable2 }
-  become: true
+    ansible.builtin.copy:
+      dest: /etc/iproute2/rt_tables.d/{{ item.name }}.conf
+      content: "{{ item.table_id }}\t{{ item.name }}\n"
+    loop:
+      - { table_id: 100, name: mytable1 }
+      - { table_id: 101, name: mytable2 }
+    become: true
   ```
   The optional `type` key supports the values
   `blackhole`, `prohibit`, and `unreachable`.


### PR DESCRIPTION
## What this PR does

Closes #536

Two documentation improvements to the `route` and `routing_rule` sections
based on user confusion reported in the issue thread.

### Change 1 — Named routing table creation example

The README already mentions that users must ensure named tables are defined
in `/etc/iproute2/rt_tables` or `/etc/iproute2/rt_tables.d/*.conf` before
using them, but gave no guidance on how to do this.

Added an `ansible.builtin.lineinfile` example showing how to create named
routing table entries alongside the network role — as suggested by @tyll  in
the issue thread.

### Change 2 — initscripts provider limitation note

Added a note in the `Limitations` section clarifying that `routing_rule`
and named `table` references in `route` are not supported when using the
`initscripts` provider.

This was explicitly requested by @alessard-trackforce who spent 4 hours
debugging this undocumented behavior.

## Testing

Documentation-only change. No code was modified.
Verified the markdown renders correctly locally.

## Summary by Sourcery

Clarify routing table usage and provider limitations in the networking role documentation.

Documentation:
- Document that the network role does not create named routing table entries and show how to manage them with an ansible.builtin.lineinfile example.
- Add a limitation note explaining that routing rules and named routing tables are not supported with the initscripts provider and will be ignored, recommending NetworkManager for routing rule support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that named routing tables must be defined before configuring routes or routing rules.
  * Added an example for creating named routing table entries.
  * Documented that routing rules and named tables are ignored with the `initscripts` provider.
  * Recommended the `nm` provider when routing rule support is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->