### PR TITLE
feat: add initial support for sle16+

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,15 +75,19 @@ __network_packages_default_wpa_supplicant: ["{%
 # distribution:
 # - python-gobject-base on RHEL7 (no python2-gobject-base :-/)
 # - python3-gobject-base on Fedora 28+
+# - python3-gobject on SUSE 16+ (no -base suffix)
 __network_packages_default_gobject_packages: ["python{{
-      ansible_facts['python']['version']['major'] | replace('2', '') }}-gobject-base"]
+      ansible_facts['python']['version']['major'] | replace('2', '') }}-gobject{{
+      '' if ansible_facts['os_family'] | d('') == 'Suse' else '-base' }}"]
 
 __network_service_name_default_nm: NetworkManager
 __network_packages_default_nm: "{{ ['NetworkManager']
       + __network_packages_default_gobject_packages | select() | list()
       + __network_packages_default_wpa_supplicant | select() | list()
       + __network_packages_default_wireless | select() | list()
-      + __network_packages_default_team | select() | list() }}"
+      + __network_packages_default_team | select() | list()
+      + (['typelib-1_0-NM-1_0']
+         if ansible_facts['os_family'] | d('') == 'Suse' else []) }}"
 
 __network_service_name_default_initscripts: network
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,15 +26,17 @@
     - ansible_facts["distribution_major_version"] | int < 8
 
 - name: Abort applying teaming configuration if the system version
-    of the managed host is EL10 or later
+    of the managed host is EL10 or later, or SUSE 16 or later
   fail:
     msg: >-
       Teaming is not supported in
       {{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }} -
       use bonding instead
   when:
-    - ansible_facts["distribution_major_version"] | int > 9
-    - ansible_facts["distribution"] in __network_rh_distros
+    - (ansible_facts["distribution_major_version"] | int > 9 and
+       ansible_facts["distribution"] in __network_rh_distros) or
+      (ansible_facts["distribution_major_version"] | int >= 16 and
+       ansible_facts["os_family"] == "Suse")
     - network_connections | selectattr("type", "defined") |
       selectattr("type", "match", "^team$") | list | length > 0 or
       network_state.get("interfaces", []) | selectattr("type", "defined") |


### PR DESCRIPTION
Enhancement:  add initial support for the network role for sle16+

Reason: The role currently fails at package install on SUSE python3-gobject-base does not exist (SUSE ships python3-goject) and typelib-1_0-NM-1_0 ships separately, not as a NetworkManager dep.

Result: update defaults/main to add typelib-1_0-NM-1_0 and manage the -base suffix for SLES.

Issue Tracker Tickets (Jira or BZ if any): na

## Summary by Sourcery

Add initial SLES 16+ support to the network role by adjusting package defaults and teaming support guards.

New Features:
- Support SLES 16+ by selecting the appropriate python-gobject package name based on OS family and adding the required NetworkManager typelib package on SUSE.

Bug Fixes:
- Prevent package installation failures on SUSE by using python3-gobject instead of the non-existent python3-gobject-base and explicitly installing typelib-1_0-NM-1_0.

Enhancements:
- Extend teaming configuration safeguards to also block teaming on SUSE 16+ systems where it is not supported.