### PR TITLE
fix: handle_exceptions is not a valid parameter

### DIFF
--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -2697,9 +2697,17 @@ class Cmd_initscripts(Cmd):
                     "1",
                     path,
                 ],
-                handle_exceptions=False,
+            )
+            self.log_info(
+                0,
+                "forget_nm_connection: rc=%d, stdout='%s', stderr='%s'"
+                % (_rc, _stdout, _stderr),
             )
         except Exception:
+            self.log_error(
+                0,
+                "forget_nm_connection: exception: %s" % (traceback.format_exc()),
+            )
             pass
 
     def run_action_absent(self, idx):


### PR DESCRIPTION
Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Improve error handling and logging when forgetting a NetworkManager connection.

Bug Fixes:
- Remove use of an invalid handle_exceptions parameter when invoking the forget_nm_connection command.

Enhancements:
- Add info and error logging of the result and any exceptions when forgetting a NetworkManager connection.