### PR TITLE
feat: Use verbosity-based logging in network role

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -157,7 +157,7 @@
     enabled: true
   when:
     - network_provider == "nm" or network_state != {}
-  no_log: true
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 # If any 802.1x connections are used, the wpa_supplicant
 # service is required to be running
@@ -176,7 +176,7 @@
     enabled: true
   when:
     - network_provider == "initscripts"
-  no_log: true
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: Ensure initscripts network file dependency is present
   copy:

--- a/tasks/set_facts.yml
+++ b/tasks/set_facts.yml
@@ -5,7 +5,7 @@
     gather_subset: "{{ __network_required_facts_subsets }}"
   when: __network_required_facts |
     difference(ansible_facts.keys() | list) | length > 0
-  no_log: true
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: Record role begin fingerprint
   sr_fingerprint:
@@ -27,9 +27,9 @@
 
 - name: Check which services are running
   service_facts:
-  no_log: true
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 # needed for ansible_facts.packages
 - name: Check which packages are installed
   package_facts:
-  no_log: true
+  no_log: "{{ ansible_verbosity < 3 }}"


### PR DESCRIPTION
This PR replaces hardcoded `no_log: true` with verbosity-based logging `no_log: "{{ ansible_verbosity < 3 }}"` throughout the network role.

## Changes

- Replace `no_log: true` with `no_log: "{{ ansible_verbosity < 3 }}"` in:
  - `tasks/set_facts.yml`: setup, service_facts, package_facts tasks
  - `tasks/main.yml`: NetworkManager and initscripts service tasks

## Rationale

In the network role, `no_log: true` was used for verbosity control to reduce verbose output from service and package fact gathering tasks, not to protect sensitive information. 

Using `ansible_verbosity < 3` allows users to see the output when debugging with increased verbosity flags (`-vvv` or higher), while keeping output concise by default.

This differs from roles where `no_log` is used for security purposes (e.g., protecting credentials or secrets), where a `*_secure_logging` parameter would be appropriate.