### PR TITLE
fix: correctly retry device read when device is unstable

### DIFF
--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -235,7 +235,7 @@ class SysUtil:
                             "cannot read stable link-infos. They keep changing"
                         )
                 except Exception:
-                    if try_count < 50:
+                    if try_count >= 50:
                         raise
                     continue
                 break

--- a/tests/unit/test_network_connections.py
+++ b/tests/unit/test_network_connections.py
@@ -5591,11 +5591,70 @@ class TestValidatorDictInfiniband(Python26CompatTestCase):
         )
 
 
-class TestSysUtils(unittest.TestCase):
+class TestSysUtils(Python26CompatTestCase):
+    def setUp(self):
+        if hasattr(SysUtil, "_link_infos"):
+            del SysUtil._link_infos
+
     def test_link_read_permaddress(self):
         self.assertEqual(SysUtil._link_read_permaddress("lo"), "00:00:00:00:00:00")
         self.assertEqual(SysUtil._link_read_permaddress("fakeiface"), None)
         self.assertEqual(SysUtil._link_read_permaddress("morethansixteenchars"), None)
+
+    def test_link_infos_retries_when_fetch_results_differ(self):
+        """Simulate unstable /sys reads; link_infos must retry, not fail once."""
+        stable = {
+            "eth0": {
+                "ifindex": 2,
+                "ifname": "eth0",
+                "address": "52:54:00:00:00:01",
+                "perm-address": None,
+                "bond-port-perm-hwaddr": None,
+            }
+        }
+        unstable = {
+            "eth1": {
+                "ifindex": 3,
+                "ifname": "eth1",
+                "address": "52:54:00:00:00:02",
+                "perm-address": None,
+                "bond-port-perm-hwaddr": None,
+            }
+        }
+        fetch_mock = mock.Mock(side_effect=[unstable, stable, stable])
+        with mock.patch.object(SysUtil, "_link_infos_fetch", fetch_mock):
+            result = SysUtil.link_infos(refresh=True)
+        self.assertEqual(result, stable)
+        self.assertEqual(fetch_mock.call_count, 3)
+
+    def test_link_infos_raises_after_max_retries(self):
+        """Unstable reads must eventually fail after 50 attempts."""
+        counter = itertools.count()
+
+        def unstable_fetch():
+            n = next(counter)
+            return {
+                "eth{n}".format(n=n): {
+                    "ifindex": n,
+                    "ifname": "eth{n}".format(n=n),
+                    "address": "52:54:00:00:00:{0:02x}".format(n % 256),
+                    "perm-address": None,
+                    "bond-port-perm-hwaddr": None,
+                }
+            }
+
+        # Use Mock(side_effect=...) so Py2.7 does not treat the replacement as an
+        # unbound method (plain functions patched onto @staticmethod fail there).
+        fetch_mock = mock.Mock(side_effect=unstable_fetch)
+        with mock.patch.object(SysUtil, "_link_infos_fetch", fetch_mock):
+            self.assertRaisesRegex(
+                Exception,
+                "stable link-infos",
+                SysUtil.link_infos,
+                refresh=True,
+            )
+        # 50 attempts: 2 fetches on first try, then 1 per retry (2 + 49 = 51).
+        self.assertEqual(fetch_mock.call_count, 51)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Cause: The retry loop for reading from a device would bail out of the loop
before retrying because the loop should have used a greater-than-or-equal
to test the retry condition rather than a less-than.

Consequence: If the device is not stable, the loop would bail and issue
an exception rather than trying to retry the read.

Fix: Use the correct loop condition.

Result: The network role can correctly retry the read when the device
is unstable.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of network interface reads so the system stops retrying at the intended limit and surfaces errors predictably when results remain unstable.

* **Tests**
  * Added unit tests to verify retry behavior: convergence to stable results and proper failure after the maximum attempts.
  * Added test setup to clear cached link-info state between tests to prevent cross-test interference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linux-system-roles/network/pull/874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->