### PR TITLE
test: fix unit test module lookup paths

### DIFF
--- a/tests/tasks/setup_remote_pytest.yml
+++ b/tests/tasks/setup_remote_pytest.yml
@@ -88,7 +88,7 @@
       elif [ "$is_coll" = true ]; then
         # search collection paths for modules and module_utils
         for dir in {{ collection_paths | join(" ") }}; do
-          for collections_dir in "$dir/ansible_collections/*/*"; do
+          for collections_dir in "$dir/ansible_collections"/*/*; do
             if [ -d "$collections_dir/plugins/modules" ] && [ -d "$collections_dir/plugins/module_utils/network_lsr" ]; then
               readlink -f "$collections_dir/plugins/modules"
               echo "${modules_to_test[@]}"


### PR DESCRIPTION
fix unit test module lookup paths

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed collection discovery path enumeration in test setup to correctly identify collection directories during iteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->