### PR TITLE
fix: escape control characters in IfcfgUtil.ValueEscape

### DIFF
--- a/library/network_connections.py
+++ b/library/network_connections.py
@@ -301,7 +301,26 @@ class IfcfgUtil:
 
     @classmethod
     def ValueEscape(cls, value):
+        """Quote a value for an ifcfg file, which is shell syntax.
 
+        Two quoting styles are produced, matching the Bash Reference
+        Manual:
+
+        ANSI-C quoting, $'...', used when the value contains a
+        character below 0x20 (Bash Reference Manual 3.1.2.4).
+        Backslash escapes are decoded per the ANSI C standard, so
+        \\nnn is the eight-bit character whose value is the *octal*
+        value nnn, one to three octal digits. Escapes are emitted at
+        a fixed three digits so they cannot absorb a following digit.
+        Backslash and single quote are escaped with a preceding
+        backslash. NUL cannot be represented; bash truncates the
+        string at it.
+
+        Double quoting, "...", used otherwise (Bash Reference Manual
+        3.1.2.3). Within double quotes the characters $, `, \\ and "
+        retain their special meaning and are escaped with a preceding
+        backslash.
+        """
         r = getattr(cls, "_re_ValueEscape", None)
         if r is None:
             r = re.compile("^[a-zA-Z_0-9-.]*$")
@@ -314,8 +333,8 @@ class IfcfgUtil:
             # needs ansic escaping due to ANSI control characters (newline)
             s = "$'"
             for c in value:
-                if ord(c) < ord(c):
-                    s += "\\" + str(ord(c))
+                if ord(c) < ord(" "):
+                    s += "\\%03o" % ord(c)
                 elif c == "\\" or c == "'":
                     s += "\\" + c
                 else:

--- a/tests/unit/test_network_connections.py
+++ b/tests/unit/test_network_connections.py
@@ -5657,5 +5657,22 @@ class TestSysUtils(Python26CompatTestCase):
         self.assertEqual(fetch_mock.call_count, 51)
 
 
+class TestIfcfgUtilValueEscape(unittest.TestCase):
+    def test_plain_value_is_not_quoted(self):
+        self.assertEqual(IfcfgUtil.ValueEscape("eth0"), "eth0")
+
+    def test_control_char_escaped_as_octal(self):
+        self.assertEqual(IfcfgUtil.ValueEscape("line1\nline2"), "$'line1\\012line2'")
+
+    def test_control_char_with_quote_and_backslash(self):
+        self.assertEqual(IfcfgUtil.ValueEscape("a\n'b\\c"), "$'a\\012\\'b\\\\c'")
+
+    def test_double_quoting_path_is_unchanged(self):
+        self.assertEqual(IfcfgUtil.ValueEscape('a "b" $c'), '"a \\"b\\" \\$c"')
+
+    def test_octal_escape_is_not_ambiguous_with_following_digit(self):
+        self.assertEqual(IfcfgUtil.ValueEscape("\x01" + "1"), "$'\\0011'")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Cause:

`IfcfgUtil.ValueEscape()` in `library/network_connections.py` guarded its
ANSI-C quoting branch with `ord(c) < ord(c)`, which is always False, so the
escaping path was unreachable. The escape also emitted `"\\" + str(ord(c))`,
a decimal code point, where ANSI-C quoting reads `\nnn` as octal.

Consequences:

Control characters were copied verbatim into the `$'...'` string.
`content_from_dict()` writes one `KEY=VALUE` per line, so a value containing
a newline broke that structure in the generated ifcfg file. Fixing only the
comparison would have exposed the second defect: newline (10) would emit
`\10`, which bash decodes as octal 10 = backspace.

Fix:

Compare against `ord(" ")` and emit `%03o`. The fixed three-digit width also
stops an escape absorbing a following digit. Uses `%` formatting to stay
Python 2.6-compatible per the constraint on `library/` code. Documents the
escaping rules in the `ValueEscape` docstring, citing Bash Reference Manual
3.1.2.3 and 3.1.2.4.

Result:

Five unit tests covering the ANSI-C path, octal-escape ambiguity, the
double-quoting path and the unquoted path.

Without the fix:

    FAILED TestIfcfgUtilValueEscape::test_control_char_escaped_as_octal
      AssertionError: "$'line1\nline2'" != "$'line1\\012line2'"
      + $'line1\012line2'
      - $'line1
      - line2'

    FAILED TestIfcfgUtilValueEscape::test_control_char_with_quote_and_backslash

With the fix: `5 passed, 153 deselected`.

Full suite on macOS: `154 passed, 3 skipped, 1 failed`. The single failure is
`TestSysUtils::test_link_read_permaddress`, which needs a Linux `SIOCETHTOOL`
ioctl and fails identically on an unpatched checkout. `black --check` and
`flake8` are clean on both changed files.

Verified the octal form round-trips:

    $ printf '%s' $'\0011' | od -c
    0000000 001   1

Issue Tracker Tickets (Jira or BZ if any): none

Signed-off-by: Suraj Patil <surajpatil522@gmail.com>