### PR TITLE
ci: use commit hash for github action version instead of version number or branch

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -39,15 +39,15 @@ jobs:
           sudo apt install -y git
 
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.20.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@d594be24ed56e586a5796720d51c261e40c20496"
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7
         with:
           python-version: ${{ matrix.versions.python }}
 

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -28,12 +28,12 @@ jobs:
           sudo apt install -y git
 
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.20.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@d594be24ed56e586a5796720d51c261e40c20496"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -42,15 +42,15 @@ jobs:
           sudo apt install -y git
 
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.20.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@d594be24ed56e586a5796720d51c261e40c20496"
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7
         with:
           python-version: ${{ matrix.versions.python }}
 

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt install -y git
 
       - name: Check out code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
       - name: Ensure the docs branch
@@ -48,12 +48,12 @@ jobs:
           fi
 
       - name: Checkout the docs branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: docs
 
       - name: Fetch README.md and .pandoc_template.html5 template from the workflow branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           sparse-checkout: |
             README.md
@@ -91,7 +91,7 @@ jobs:
         run: cp ${{ env.RELEASE_VERSION }}/README.html docs/index.html
 
       - name: Upload README.html as an artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: README.html
           path: ${{ env.RELEASE_VERSION }}/README.html
@@ -104,7 +104,7 @@ jobs:
           git commit -m "Update README.html for ${{ env.RELEASE_VERSION }}"
 
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c  # master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: docs

--- a/.github/workflows/changelog_to_tag.yml
+++ b/.github/workflows/changelog_to_tag.yml
@@ -22,7 +22,7 @@ jobs:
           sudo apt install -y git
 
       - name: checkout PR
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Get tag and message from the latest CHANGELOG.md commit
         id: tag
@@ -69,7 +69,7 @@ jobs:
           echo "tagname=$_tagname" >> "$GITHUB_OUTPUT"
           echo "branch=$_branch" >> "$GITHUB_OUTPUT"
       - name: Create tag
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b  # v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.tag.outputs.tagname }}
@@ -77,7 +77,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1
         with:
           tag: ${{ steps.tag.outputs.tagname }}
           name: Version ${{ steps.tag.outputs.tagname }}
@@ -85,7 +85,7 @@ jobs:
           makeLatest: true
 
       - name: Publish role to Galaxy
-        uses: robertdebock/galaxy-action@1.2.1
+        uses: robertdebock/galaxy-action@7d89099e09f4385ec4b53eb58c0d120f1ad806dd  # 1.2.1
         with:
           galaxy_api_key: ${{ secrets.galaxy_api_key }}
           git_branch: ${{ steps.tag.outputs.branch }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,18 +34,18 @@ jobs:
           sudo apt update
           sudo apt install -y git
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.4
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4.37.4
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4.37.4
+        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4.37.4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.4
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4.37.4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Codespell
-        uses: codespell-project/actions-codespell@v2
+        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630  # v2

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -28,7 +28,7 @@ jobs:
           sudo apt install -y git
 
       - name: Check out code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       # CHANGELOG.md is generated automatically from PR titles and descriptions
       # It might have issues but they are not critical

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -18,7 +18,7 @@ jobs:
   commit-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -43,7 +43,7 @@ jobs:
           sudo apt install -y git
 
       - name: checkout PR
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Set up Python 2.7
         if: ${{ matrix.pyver_os.ver == '2.7' }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Set up Python 3
         if: ${{ matrix.pyver_os.ver != '2.7' }}
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7
         with:
           python-version: ${{ matrix.pyver_os.ver }}
 
@@ -70,7 +70,7 @@ jobs:
             tox=tox
             virtualenv=virtualenv
           fi
-          pip install "$tox" "$virtualenv" "git+https://github.com/linux-system-roles/tox-lsr@3.20.1"
+          pip install "$tox" "$virtualenv" "git+https://github.com/linux-system-roles/tox-lsr@d594be24ed56e586a5796720d51c261e40c20496"
           # If you have additional OS dependency packages e.g. libcairo2-dev
           # then put them in .github/config/ubuntu-requirements.txt, one
           # package per line.
@@ -92,4 +92,4 @@ jobs:
           TOXENV="$toxenvs" lsr_ci_runtox
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Check if platform is supported
         id: check_platform
@@ -111,7 +111,7 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.20.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@d594be24ed56e586a5796720d51c261e40c20496"
 
       - name: Check for podman version 5 or higher
         id: check_podman_version
@@ -128,7 +128,7 @@ jobs:
 
       - name: Ensure use of podman 5
         if: steps.check_platform.outputs.supported && steps.check_podman_version.outputs.need_podman_update == 1
-        uses: redhat-actions/podman-install@main
+        uses: redhat-actions/podman-install@3b6c60c447c93960c0b76faa0c66c6694bc71350  # main
 
       - name: Configure tox-lsr
         if: steps.check_platform.outputs.supported
@@ -212,7 +212,7 @@ jobs:
 
       - name: Upload test logs on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: "logs-${{ matrix.scenario.image }}-${{ matrix.scenario.env }}"
           path: |
@@ -238,7 +238,7 @@ jobs:
 
       - name: Set commit status as success with a description that platform is skipped
         if: ${{ steps.check_platform.outputs.supported == '' }}
-        uses: myrotvorets/set-commit-status-action@master
+        uses: myrotvorets/set-commit-status-action@2774e1f040c82ed70a76b4b5cd53bb11ffaedd0a  # master
         with:
           status: success
           context: "${{ github.workflow }} / scenario (${{ matrix.scenario.image }}, ${{ matrix.scenario.env }}) (pull_request)"

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -30,11 +30,11 @@ jobs:
           sudo apt install -y git
 
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Run ShellCheck
         id: shellcheck_id
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca  # master
 
       - name: Show file paths scanned
         run: |

--- a/.github/workflows/test_converting_readme.yml
+++ b/.github/workflows/test_converting_readme.yml
@@ -29,7 +29,7 @@ jobs:
           sudo apt install -y git
 
       - name: Check out code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Remove badges from README.md prior to converting to HTML
         run: sed -i '1,8 {/^\[\!.*actions\/workflows/d}' README.md
@@ -43,7 +43,7 @@ jobs:
             --output README.html README.md
 
       - name: Upload README.html as an artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: README.html
           path: README.html

--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -36,7 +36,7 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
 
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Get head sha of the PR
         id: head_sha
@@ -49,7 +49,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout PR
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ steps.head_sha.outputs.head_sha }}
 
@@ -136,7 +136,7 @@ jobs:
 
       - name: Set commit status as pending
         if: contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
-        uses: myrotvorets/set-commit-status-action@master
+        uses: myrotvorets/set-commit-status-action@2774e1f040c82ed70a76b4b5cd53bb11ffaedd0a  # master
         with:
           sha: ${{ needs.prepare_vars.outputs.head_sha }}
           status: pending
@@ -146,7 +146,7 @@ jobs:
 
       - name: Set commit status as success with a description that platform is skipped
         if: "!contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)"
-        uses: myrotvorets/set-commit-status-action@master
+        uses: myrotvorets/set-commit-status-action@2774e1f040c82ed70a76b4b5cd53bb11ffaedd0a  # master
         with:
           sha: ${{ needs.prepare_vars.outputs.head_sha }}
           status: success
@@ -155,7 +155,7 @@ jobs:
           targetUrl: ""
 
       - name: Run test in testing farm
-        uses: sclorg/testing-farm-as-github-action@v4
+        uses: sclorg/testing-farm-as-github-action@230555baceb860aa468d216f1822974836b965d1  # v4
         if: contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
         with:
           git_ref: main
@@ -184,7 +184,7 @@ jobs:
           tmt_plan_filter: "tag:playbooks_parallel,network"
 
       - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@master
+        uses: myrotvorets/set-commit-status-action@2774e1f040c82ed70a76b4b5cd53bb11ffaedd0a  # master
         if: always() && contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
         with:
           sha: ${{ needs.prepare_vars.outputs.head_sha }}

--- a/.github/workflows/weekly_ci.yml
+++ b/.github/workflows/weekly_ci.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt install -y git
 
       - name: Checkout latest code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
       - name: Create or rebase commit, add dump_packages callback
@@ -50,7 +50,7 @@ jobs:
           git push -f --set-upstream origin ${{ env.BRANCH_NAME }}
 
       - name: Create and comment pull request
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           github-token: ${{ secrets.GH_PUSH_TOKEN }}
           script: |

--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Run lsr-woke-action
         # Originally, uses: get-woke/woke-action@v0
-        uses: linux-system-roles/lsr-woke-action@main
+        uses: linux-system-roles/lsr-woke-action@c9aa70dcf848deb3e1bf4fdea085ce49bf02341b  # main
         with:
           woke-args: "-c https://raw.githubusercontent.com/linux-system-roles/tox-lsr/main/src/tox_lsr/config_files/woke.yml --count-only-error-for-failure"
           # Cause the check to fail on any broke rules


### PR DESCRIPTION
The latest security guidance is to use the full commit hash, which is immutable,
instead of a tag or version, which is mutable, for the reference to a version
of a github action.  There are known attacks which inserted unauthorized code
in a version tag and moved the tag.  This prevents this sort of attack, at the
cost of more maintenance burden, but dependabot will largely take care of this
for us.

Each version or tag has been replaced with the corresponding commit hash - in some
cases, this is not the latest commit on the main branch, so I would expect to see
some dependabot updates in the near future.  I thought it was safer to do it this
way - preserve existing behavior/functionality - rather than replace and upgrade
to a newer version at the same time.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned workflow actions and supporting tooling to immutable revisions.
  * Improved the consistency and reproducibility of automated builds, tests, documentation, security scans, and release workflows.
  * Preserved existing workflow behavior while reducing reliance on changeable version tags and branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->